### PR TITLE
Add Tox configuration, run Travis builds with Tox

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,13 +1,13 @@
-*.pyc
-*.pyo
-__pycache__
+*.py[co]
+__pycache__/
 
-.pytest_cache
+.tox/
+.pytest_cache/
 
-*.wpu
+dist/
+build/
+*.egg-info/
 
 *.bak
 
-dist
-build
-*.egg-info
+*.wpu

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 dist: xenial
 language: python
+
 python:
 - 2.7
 - 3.4
@@ -10,10 +11,37 @@ python:
 - pypy2.7-6.0
 - pypy3.5
 
-env:
- - PYTHONWARNINGS='ignore::DeprecationWarning' # Until python_toolbox is fixed
-
 install:
-- pip install -r test_requirements.txt
+- pip install tox-travis
 script:
-- pytest
+- tox
+
+stages:
+- lint
+- test
+- deploy
+
+matrix:
+  allow_failures:
+  - env: TOXENV=flake8
+  - env: TOXENV=pylint
+  - env: TOXENV=bandit
+
+jobs:
+  include:
+  - { stage: lint, python: 3.7, env: TOXENV=flake8 }
+  - { stage: lint, python: 3.7, env: TOXENV=pylint }
+  - { stage: lint, python: 3.7, env: TOXENV=bandit }
+  - { stage: lint, python: 3.7, env: TOXENV=readme }
+
+  - stage: deploy
+    install: skip
+    script: skip
+    deploy:
+      provider: pypi
+      distributions: sdist bdist_wheel
+      user: cool-RR
+      password:
+        secure: <your-pypi-password-here-encrypted-using-the-travis-cli>
+      on:
+        tags: true

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ What makes **PySnooper** stand out from all other code intelligence tools? You c
 # Example #
 
 We're writing a function that converts a number to binary, by returning a list of bits. Let's snoop on it by adding the `@pysnooper.snoop()` decorator:
+
 ```python
 import pysnooper
 
@@ -35,62 +36,103 @@ number_to_bits(6)
 ```
 The output to stderr is:
 
-    Starting var:.. number = 6
-    21:14:32.099769 call         3 @pysnooper.snoop()
-    21:14:32.099769 line         5     if number:
-    21:14:32.099769 line         6         bits = []
-    New var:....... bits = []
-    21:14:32.099769 line         7         while number:
-    21:14:32.099769 line         8             number, remainder = divmod(number, 2)
-    New var:....... remainder = 0
-    Modified var:.. number = 3
-    21:14:32.099769 line         9             bits.insert(0, remainder)
-    Modified var:.. bits = [0]
-    21:14:32.099769 line         7         while number:
-    21:14:32.099769 line         8             number, remainder = divmod(number, 2)
-    Modified var:.. number = 1
-    Modified var:.. remainder = 1
-    21:14:32.099769 line         9             bits.insert(0, remainder)
-    Modified var:.. bits = [1, 0]
-    21:14:32.099769 line         7         while number:
-    21:14:32.099769 line         8             number, remainder = divmod(number, 2)
-    Modified var:.. number = 0
-    21:14:32.099769 line         9             bits.insert(0, remainder)
-    Modified var:.. bits = [1, 1, 0]
-    21:14:32.099769 line         7         while number:
-    21:14:32.099769 line        10         return bits
-    21:14:32.099769 return      10         return bits
-
+```
+Starting var:.. number = 6
+21:14:32.099769 call         3 @pysnooper.snoop()
+21:14:32.099769 line         5     if number:
+21:14:32.099769 line         6         bits = []
+New var:....... bits = []
+21:14:32.099769 line         7         while number:
+21:14:32.099769 line         8             number, remainder = divmod(number, 2)
+New var:....... remainder = 0
+Modified var:.. number = 3
+21:14:32.099769 line         9             bits.insert(0, remainder)
+Modified var:.. bits = [0]
+21:14:32.099769 line         7         while number:
+21:14:32.099769 line         8             number, remainder = divmod(number, 2)
+Modified var:.. number = 1
+Modified var:.. remainder = 1
+21:14:32.099769 line         9             bits.insert(0, remainder)
+Modified var:.. bits = [1, 0]
+21:14:32.099769 line         7         while number:
+21:14:32.099769 line         8             number, remainder = divmod(number, 2)
+Modified var:.. number = 0
+21:14:32.099769 line         9             bits.insert(0, remainder)
+Modified var:.. bits = [1, 1, 0]
+21:14:32.099769 line         7         while number:
+21:14:32.099769 line        10         return bits
+21:14:32.099769 return      10         return bits
+```
 
 # Features #
 
 If stderr is not easily accessible for you, you can redirect the output to a file:
 
-    @pysnooper.snoop('/my/log/file.log')
+```python
+@pysnooper.snoop('/my/log/file.log')
+```
 
 See values of some variables that aren't local variables:
 
-    @pysnooper.snoop(variables=('foo.bar', 'self.whatever'))
+```python
+@pysnooper.snoop(variables=('foo.bar', 'self.whatever'))
+```
 
 Show snoop lines for functions that your function calls:
 
-    @pysnooper.snoop(depth=2)
+```python
+@pysnooper.snoop(depth=2)
+```
 
 Start all snoop lines with a prefix, to grep for them easily:
 
-    @pysnooper.snoop(prefix='ZZZ ')
-
+```python
+@pysnooper.snoop(prefix='ZZZ ')
+```
 
 # Installation #
 
-Use `pip`:
+```console
+$ pip install pysnooper
+```
 
-    pip install pysnooper
+If you lack permission for system-wide installation:
+```console
+$ pip install --user pysnooper
+```
 
+# Contribute #
 
-# Copyright #
+[Pull requests](https://github.com/cool-RR/PySnooper/pulls) are always welcome!
+Please, write tests and run them with [Tox](https://tox.readthedocs.io/).
+
+Tox installs all dependencies automatically. You only need to install Tox itself:
+
+```console
+$ pip install tox
+```
+
+List all environments `tox` would run:
+
+```console
+$ tox -lv
+```
+
+If you want to run tests agains all target Python versions use [pyenv](
+https://github.com/pyenv/pyenv) to install them. Otherwise, you can run
+only linters and the ones you have already installed on your machine:
+
+```console
+# run only some environments
+$ tox -e flake8,pylint,bandit,py27,py36
+```
+
+Linters and tests should pass before you push your code. They will be run again on Travis CI.
+
+# License #
 
 Copyright (c) 2019 Ram Rachum, released under the MIT license.
 
-I provide
-[Development services in Python and Django](https://chipmunkdev.com) and I [give Python workshops](http://pythonworkshops.co/) to teach people Python and related topics.
+I provide [Development services in Python and Django](https://chipmunkdev.com
+) and I [give Python workshops](http://pythonworkshops.co/) to teach people
+Python and related topics.

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,5 +1,0 @@
--r requirements.txt
-
-pip-tools
-pytest
-python_toolbox

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,65 @@
+# tox (https://tox.readthedocs.io/) is a tool for running tests
+# Run tests in multiple virtualenvs.
+
+[tox]
+envlist =
+    flake8
+    pylint
+    bandit
+    py{27,34,35,36,37,38,py,py3}
+    readme
+    requirements
+    clean
+
+[testenv]
+description = Unit tests
+deps =
+    pytest
+    python_toolbox
+commands = pytest
+setenv =
+    # until python_toolbox is fixed
+    PYTHONWARNINGS = ignore::DeprecationWarning
+
+[testenv:bandit]
+description = PyCQA security linter
+deps = bandit
+commands = bandit -r --ini tox.ini
+
+[testenv:clean]
+description = Clean up bytecode
+deps = pyclean
+commands = py3clean -v {toxinidir}
+
+[testenv:flake8]
+description = Static code analysis and code style
+deps = flake8
+commands = flake8
+
+[testenv:pylint]
+description = Check for errors and code smells
+deps = pylint
+commands = pylint pysnooper setup
+
+[testenv:readme]
+description = Ensure README renders on PyPI
+deps = twine
+commands =
+    {envpython} setup.py -q sdist bdist_wheel
+    twine check dist/*
+
+[testenv:requirements]
+description = Update requirements.txt
+deps = pip-tools
+commands = pip-compile --output-file requirements.txt requirements.in
+changedir = {toxinidir}
+
+[bandit]
+exclude = .tox,build,dist,tests
+targets = .
+
+[flake8]
+exclude = .tox,build,dist,pysnooper.egg-info
+
+[pytest]
+addopts = --strict --verbose


### PR DESCRIPTION
- Adds tox.ini with environments for popular linters, unit tests and clean-up
- Use Tox in Travis CI configuration with tox-travis Python package
- Allow linting to fail for now (to allow slow adoption)
- Add contribution instructions to README, update README markup
- Remove obsolete `test_requirements.txt` (covered by `deps` in tox.ini)
- Update `.gitignore` file

Fixes: #23
Prepares: #24
