### PR TITLE
Support color in output #1

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,24 @@ Start all snoop lines with a prefix, to grep for them easily:
 @pysnooper.snoop(prefix='ZZZ ')
 ```
 
+Show output coloring, default color dict {"newish":"green","modified":"orange","def":"blue","return":"cyan"}::
+        
+```python
+@pysnooper.snoop()
+```
+
+to disabled colorful output, just make color to *None*:
+
+```python
+@pysnooper.snoop(color=None)
+``` 
+
+or just change centain color:
+
+```python
+@pysnooper.snoop(color={"newish":"red"})
+```
+
 # Installation #
 
 ```console

--- a/pysnooper/pysnooper.py
+++ b/pysnooper/pysnooper.py
@@ -3,7 +3,7 @@
 
 import sys
 
-from .third_party import decorator
+from .third_party import decorator, hue
 
 from . import utils
 from . import pycompat
@@ -32,7 +32,8 @@ def get_write_and_truncate_functions(output):
     return (write, truncate)
 
 
-def snoop(output=None, variables=(), depth=1, prefix='', overwrite=False):
+
+def snoop(output=None, variables=(), depth=1, prefix='', overwrite=False, color={"newish":"green","modified":"orange","def":"blue","return":"cyan"}):
     '''
     Snoop on the function, writing everything it's doing to stderr.
 
@@ -59,6 +60,18 @@ def snoop(output=None, variables=(), depth=1, prefix='', overwrite=False):
 
         @pysnooper.snoop(prefix='ZZZ ')
 
+    Show output coloring, default color dict {"newish":"green","modified":"orange","def":"blue","return":"cyan"}::
+        
+        @pysnooper.snoop()
+
+    to disabled colorful output, just make color to None::
+
+        @pysnooper.snoop(color=None)
+    
+    or just change centain color::
+
+        @pysnooper.snoop(color={"newish":"red"})
+
     '''
     write, truncate = get_write_and_truncate_functions(output)
     if truncate is None and overwrite:
@@ -68,7 +81,7 @@ def snoop(output=None, variables=(), depth=1, prefix='', overwrite=False):
         target_code_object = function.__code__
         tracer = Tracer(target_code_object=target_code_object, write=write,
                         truncate=truncate, variables=variables, depth=depth,
-                        prefix=prefix, overwrite=overwrite)
+                        prefix=prefix, overwrite=overwrite, color=color)
 
         def inner(function_, *args, **kwargs):
             with tracer:

--- a/pysnooper/third_party/hue.py
+++ b/pysnooper/third_party/hue.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python
+
+import ctypes
+import platform
+
+if platform.system() == 'Windows':
+    kernel32 = ctypes.windll.kernel32
+    kernel32.SetConsoleMode(kernel32.GetStdHandle(-11), 7)
+
+COMMANDS = {
+    'green': 32,
+    'lightgreen': 92,
+    'grey': 37,
+    'black': 30,
+    'red': 31,
+    'lightred': 91,
+    'cyan': 36,
+    'lightcyan': 96,
+    'blue': 34,
+    'lightblue': 94,
+    'purple': 35,
+    'yellow': 93,
+    'white': 97,
+    'lightpurple': 95,
+    'orange': 33
+}
+
+
+def _gen(string, prefix, key):
+    colored = prefix if prefix else string
+    not_colored = string if prefix else ''
+    return u'\033[{}m{}\033[0m{}\n'.format(key, colored, not_colored)
+
+
+for key, val in COMMANDS.items():
+    value = val[0] if isinstance(val, tuple) else val
+    prefix = val[1] if isinstance(val, tuple) else ''
+    locals()[key] = lambda s, prefix=prefix, key=value: _gen(s, prefix, key)
+
+__all__ = list(COMMANDS.keys())


### PR DESCRIPTION
I'm so sorry that i get wrong idea about outoup coloring. So i make a new pr,which result like the picture below:
![](http://ww1.sinaimg.cn/large/006wYWbGly1g2g9c1pq10j30jd0bzq4j.jpg)

Show output coloring, default color dict {"newish":"green","modified":"orange","def":"blue","return":"cyan"}::
        
```python
@pysnooper.snoop()
```

to disabled colorful output, just make color to *None*:

```python
@pysnooper.snoop(color=None)
``` 

or just change centain color:

```python
@pysnooper.snoop(color={"newish":"red"})
```
