### PR TITLE
Use cheap_repr

### DIFF
--- a/pysnooper/tracer.py
+++ b/pysnooper/tracer.py
@@ -9,27 +9,18 @@ import itertools
 
 from .third_party import six
 
+from cheap_repr import cheap_repr
+
 MAX_VARIABLE_LENGTH = 100
 ipython_filename_pattern = re.compile('^<ipython-input-([0-9]+)-.*>$')
 
 
-def get_shortish_repr(item):
-    try:
-        r = repr(item)
-    except Exception:
-        r = 'REPR FAILED'
-    r = r.replace('\r', '').replace('\n', '')
-    if len(r) > MAX_VARIABLE_LENGTH:
-        r = '{truncated_r}...'.format(truncated_r=r[:MAX_VARIABLE_LENGTH])
-    return r
-
-
 def get_local_reprs(frame, variables=()):
-    result = {key: get_shortish_repr(value) for key, value
+    result = {key: cheap_repr(value) for key, value
                                                      in frame.f_locals.items()}
     for variable in variables:
         try:
-            result[variable] = get_shortish_repr(
+            result[variable] = cheap_repr(
                 eval(variable, frame.f_globals, frame.f_locals)
             )
         except Exception:
@@ -230,7 +221,7 @@ class Tracer:
                    '{line_no:4} {source_line}'.format(**locals()))
 
         if event == 'return':
-            return_value_repr = get_shortish_repr(arg)
+            return_value_repr = cheap_repr(arg)
             self.write('{indent}Return value:.. {return_value_repr}'.
                                                             format(**locals()))
 

--- a/requirements.in
+++ b/requirements.in
@@ -1,1 +1,1 @@
-# That's right baby! No dependencies!
+cheap_repr

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,5 @@
 #
 #    pip-compile --output-file requirements.txt requirements.in
 #
-cheap-repr==0.3.0
-future==0.17.1            # via cheap-repr
+cheap-repr==0.3.1
 qualname==0.1.0           # via cheap-repr

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,6 @@
 #
 #    pip-compile --output-file requirements.txt requirements.in
 #
+cheap-repr==0.3.0
+future==0.17.1            # via cheap-repr
+qualname==0.1.0           # via cheap-repr

--- a/tox.ini
+++ b/tox.ini
@@ -16,6 +16,7 @@ description = Unit tests
 deps =
     pytest
     python_toolbox
+    -rrequirements.txt
 commands = pytest
 setenv =
     # until python_toolbox is fixed


### PR DESCRIPTION
[cheap_repr](https://github.com/alexmojaki/cheap_repr) is my library. It may seem obscure but it's a core dependency of my debugger [birdseye](https://github.com/alexmojaki/birdseye), so it's battle tested.

Using it would be a significant improvement to performance and provide more useful information to the user.

It looks like you don't want to have external dependencies, which I'm guessing is going to be a problem. What's that about?