### PR TITLE
Make cheap_repr an optional dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,7 @@ jobs:
   - { stage: lint, python: 3.7, env: TOXENV=pylint }
   - { stage: lint, python: 3.7, env: TOXENV=bandit }
   - { stage: lint, python: 3.7, env: TOXENV=readme }
+  - { stage: test, python: 3.7, env: TOXENV=cheap_repr }
 
   - stage: deploy
     install: skip

--- a/pysnooper/tracer.py
+++ b/pysnooper/tracer.py
@@ -12,16 +12,18 @@ from .third_party import six
 MAX_VARIABLE_LENGTH = 100
 ipython_filename_pattern = re.compile('^<ipython-input-([0-9]+)-.*>$')
 
-
-def get_shortish_repr(item):
-    try:
-        r = repr(item)
-    except Exception:
-        r = 'REPR FAILED'
-    r = r.replace('\r', '').replace('\n', '')
-    if len(r) > MAX_VARIABLE_LENGTH:
-        r = '{truncated_r}...'.format(truncated_r=r[:MAX_VARIABLE_LENGTH])
-    return r
+try:
+    from cheap_repr import cheap_repr as get_shortish_repr
+except ImportError:
+    def get_shortish_repr(item):
+        try:
+            r = repr(item)
+        except Exception:
+            r = 'REPR FAILED'
+        r = r.replace('\r', '').replace('\n', '')
+        if len(r) > MAX_VARIABLE_LENGTH:
+            r = '{truncated_r}...'.format(truncated_r=r[:MAX_VARIABLE_LENGTH])
+        return r
 
 
 def get_local_reprs(frame, variables=()):

--- a/tox.ini
+++ b/tox.ini
@@ -21,6 +21,10 @@ setenv =
     # until python_toolbox is fixed
     PYTHONWARNINGS = ignore::DeprecationWarning
 
+[testenv:cheap_repr]
+description = Unit tests with cheap_repr installed
+deps = cheap_repr
+
 [testenv:bandit]
 description = PyCQA security linter
 deps = bandit

--- a/tox.ini
+++ b/tox.ini
@@ -23,7 +23,10 @@ setenv =
 
 [testenv:cheap_repr]
 description = Unit tests with cheap_repr installed
-deps = cheap_repr
+deps =
+    pytest
+    python_toolbox
+    cheap_repr
 
 [testenv:bandit]
 description = PyCQA security linter


### PR DESCRIPTION
Compromise to #68. cheap_repr will only be activated if the user installs it separately, which we can recommend in the docs. We could make it an install extra in setup.py, but I don't think there's much point in that.