### PR TITLE
Add classes to automatically track attributes, keys, etc. of variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,14 @@ See values of some variables that aren't local variables:
 @pysnooper.snoop(variables=('foo.bar', 'self.whatever'))
 ```
 
+Expand values to see all their attributes or items of lists/dictionaries:
+
+```python
+@pysnooper.snoop(exploding_variables=('foo', 'self'))
+```
+
+(see [Advanced Usage](#advanced-usage) for more control)
+
 Show snoop lines for functions that your function calls:
 
 ```python
@@ -98,6 +106,24 @@ Start all snoop lines with a prefix, to grep for them easily:
 ```console
 $ pip install pysnooper
 ```
+
+# Advanced Usage #
+
+`exploding_variables` will automatically guess how to expand the expression passed to it based on its class. You can be more specific by using one of the following classes:
+
+```python
+import pysnooper
+
+@pysnooper.snoop(variables=(
+    pysnooper.Attrs('x'),    # attributes
+    pysnooper.Keys('y'),     # mapping (e.g. dict) items
+    pysnooper.Indices('z'),  # sequence (e.g. list/tuple) items
+))
+```
+
+Exclude specific keys/attributes/indices with the `exclude` parameter, e.g. `Attrs('x', exclude=('_foo', '_bar'))`.
+
+Add a slice after `Indices` to only see the values within that slice, e.g. `Indices('z')[-3:]`.
 
 # Contribute #
 

--- a/README.md
+++ b/README.md
@@ -75,10 +75,10 @@ If stderr is not easily accessible for you, you can redirect the output to a fil
 
 You can also pass a stream or a callable instead, and they'll be used.
 
-See values of some variables that aren't local variables:
+See values of some expressions that aren't local variables:
 
 ```python
-@pysnooper.snoop(variables=('foo.bar', 'self.whatever'))
+@pysnooper.snoop(watch=('foo.bar', 'self.x["whatever"]'))
 ```
 
 Expand values to see all their attributes or items of lists/dictionaries:

--- a/pysnooper/__init__.py
+++ b/pysnooper/__init__.py
@@ -2,6 +2,7 @@
 # This program is distributed under the MIT license.
 
 from .pysnooper import snoop
+from .variables import Attrs, Exploded, Indices, Keys
 import collections
 
 __VersionInfo = collections.namedtuple('VersionInfo',

--- a/pysnooper/__init__.py
+++ b/pysnooper/__init__.py
@@ -2,13 +2,13 @@
 # This program is distributed under the MIT license.
 
 from .pysnooper import snoop
-from .variables import Attrs, Exploded, Indices, Keys
+from .variables import Attrs, Exploding, Indices, Keys
 import collections
 
 __VersionInfo = collections.namedtuple('VersionInfo',
                                        ('major', 'minor', 'micro'))
 
-__version__ = '0.0.26'
+__version__ = '0.0.27'
 __version_info__ = __VersionInfo(*(map(int, __version__.split('.'))))
 
 del collections, __VersionInfo # Avoid polluting the namespace

--- a/pysnooper/pysnooper.py
+++ b/pysnooper/pysnooper.py
@@ -39,7 +39,8 @@ def get_write_and_truncate_functions(output):
     return (write, truncate)
 
 
-def snoop(output=None, variables=(), exploded_variables=(), depth=1, prefix='', overwrite=False):
+def snoop(output=None, watch=(), watch_explode=(), depth=1,
+          prefix='', overwrite=False):
     '''
     Snoop on the function, writing everything it's doing to stderr.
 
@@ -54,9 +55,9 @@ def snoop(output=None, variables=(), exploded_variables=(), depth=1, prefix='', 
 
         @pysnooper.snoop('/my/log/file.log')
 
-    See values of some variables that aren't local variables::
+    See values of some expressions that aren't local variables::
 
-        @pysnooper.snoop(variables=('foo.bar', 'self.whatever'))
+        @pysnooper.snoop(watch=('foo.bar', 'self.x["whatever"]'))
 
     Expand values to see all their attributes or items of lists/dictionaries:
 
@@ -79,10 +80,11 @@ def snoop(output=None, variables=(), exploded_variables=(), depth=1, prefix='', 
                         "content to file.")
     def decorate(function):
         target_code_object = function.__code__
-        tracer = Tracer(target_code_object=target_code_object, write=write,
-                        truncate=truncate, variables=variables, depth=depth,
-                        prefix=prefix, overwrite=overwrite,
-                        exploded_variables=exploded_variables)
+        tracer = Tracer(
+            target_code_object=target_code_object, write=write,
+            truncate=truncate, watch=watch, watch_explode=watch_explode,
+            depth=depth, prefix=prefix, overwrite=overwrite
+        )
 
         def inner(function_, *args, **kwargs):
             with tracer:

--- a/pysnooper/pysnooper.py
+++ b/pysnooper/pysnooper.py
@@ -39,7 +39,7 @@ def get_write_and_truncate_functions(output):
     return (write, truncate)
 
 
-def snoop(output=None, variables=(), depth=1, prefix='', overwrite=False):
+def snoop(output=None, variables=(), exploded_variables=(), depth=1, prefix='', overwrite=False):
     '''
     Snoop on the function, writing everything it's doing to stderr.
 
@@ -75,7 +75,8 @@ def snoop(output=None, variables=(), depth=1, prefix='', overwrite=False):
         target_code_object = function.__code__
         tracer = Tracer(target_code_object=target_code_object, write=write,
                         truncate=truncate, variables=variables, depth=depth,
-                        prefix=prefix, overwrite=overwrite)
+                        prefix=prefix, overwrite=overwrite,
+                        exploded_variables=exploded_variables)
 
         def inner(function_, *args, **kwargs):
             with tracer:

--- a/pysnooper/pysnooper.py
+++ b/pysnooper/pysnooper.py
@@ -58,6 +58,12 @@ def snoop(output=None, variables=(), exploded_variables=(), depth=1, prefix='', 
 
         @pysnooper.snoop(variables=('foo.bar', 'self.whatever'))
 
+    Expand values to see all their attributes or items of lists/dictionaries:
+
+        @pysnooper.snoop(exploding_variables=('foo', 'self'))
+
+    (see Advanced Usage in the README for more control)
+
     Show snoop lines for functions that your function calls::
 
         @pysnooper.snoop(depth=2)

--- a/pysnooper/tracer.py
+++ b/pysnooper/tracer.py
@@ -7,7 +7,7 @@ import collections
 import datetime as datetime_module
 import itertools
 
-from .variables import Variable
+from .variables import CommonVariable, Exploded, BaseVariable
 from .third_party import six
 from .utils import get_shortish_repr, ensure_tuple
 
@@ -99,13 +99,16 @@ def get_source_from_frame(frame):
 
 class Tracer:
     def __init__(self, target_code_object, write, truncate, variables=(),
-                 depth=1, prefix='', overwrite=False):
+                 exploded_variables=(), depth=1, prefix='', overwrite=False):
         self.target_code_object = target_code_object
         self._write = write
         self.truncate = truncate
         self.variables = [
-            v if isinstance(v, Variable) else Variable(v)
+            v if isinstance(v, BaseVariable) else CommonVariable(v)
             for v in ensure_tuple(variables)
+         ] + [
+             v if isinstance(v, BaseVariable) else Exploded(v)
+             for v in ensure_tuple(exploded_variables)
         ]
         self.frame_to_old_local_reprs = collections.defaultdict(lambda: {})
         self.frame_to_local_reprs = collections.defaultdict(lambda: {})

--- a/pysnooper/tracer.py
+++ b/pysnooper/tracer.py
@@ -9,13 +9,14 @@ import itertools
 
 from .variables import CommonVariable, Exploded, BaseVariable
 from .third_party import six
-from .utils import get_shortish_repr, ensure_tuple
+from . import utils
+
 
 ipython_filename_pattern = re.compile('^<ipython-input-([0-9]+)-.*>$')
 
 
 def get_local_reprs(frame, variables=()):
-    result = {key: get_shortish_repr(value) for key, value
+    result = {key: utils.get_shortish_repr(value) for key, value
                                                      in frame.f_locals.items()}
     for variable in variables:
         result.update(variable.items(frame))
@@ -105,10 +106,10 @@ class Tracer:
         self.truncate = truncate
         self.variables = [
             v if isinstance(v, BaseVariable) else CommonVariable(v)
-            for v in ensure_tuple(variables)
+            for v in utils.ensure_tuple(variables)
          ] + [
              v if isinstance(v, BaseVariable) else Exploded(v)
-             for v in ensure_tuple(exploded_variables)
+             for v in utils.ensure_tuple(exploded_variables)
         ]
         self.frame_to_old_local_reprs = collections.defaultdict(lambda: {})
         self.frame_to_local_reprs = collections.defaultdict(lambda: {})
@@ -219,7 +220,7 @@ class Tracer:
                    u'{line_no:4} {source_line}'.format(**locals()))
 
         if event == 'return':
-            return_value_repr = get_shortish_repr(arg)
+            return_value_repr = utils.get_shortish_repr(arg)
             self.write('{indent}Return value:.. {return_value_repr}'.
                                                             format(**locals()))
 

--- a/pysnooper/utils.py
+++ b/pysnooper/utils.py
@@ -2,9 +2,17 @@
 # This program is distributed under the MIT license.
 
 import abc
-import sys
 
 from .pycompat import ABC
+from .third_party import six
+
+try:
+    import reprlib
+    import builtins
+except ImportError:
+    import repr as reprlib
+    import __builtin__ as builtins
+
 
 def _check_methods(C, *methods):
     mro = C.__mro__
@@ -31,6 +39,7 @@ class WritableStream(ABC):
         return NotImplemented
 
 
+
 file_reading_errors = (
     IOError,
     OSError,
@@ -38,7 +47,47 @@ file_reading_errors = (
 )
 
 
+
 def shitcode(s):
     return ''.join(
         (c if (0 < ord(c) < 256) else '?') for c in s
     )
+
+
+class Repr(reprlib.Repr, object):  # reprlib.Repr is old-style in Python 2
+    def __init__(self):
+        super(Repr, self).__init__()
+        self.maxother = 100
+
+    def repr(self, x):
+        try:
+            return super(Repr, self).repr(x)
+        except Exception as e:
+            return '<{} instance at {:#x} (__repr__ raised {})>'.format(
+                x.__class__.__name__, id(x), e.__class__.__name__)
+
+    def repr_instance(self, x, level):
+        s = builtins.repr(x)
+        if len(s) > self.maxother:
+            i = max(0, (self.maxother - 3) // 2)
+            j = max(0, self.maxother - 3 - i)
+            s = s[:i] + '...' + s[len(s) - j:]
+        return s
+
+
+repr_instance = Repr()
+
+
+def get_shortish_repr(item):
+    r = repr_instance.repr(item)
+    r = r.replace('\r', '').replace('\n', '')
+    return r
+
+
+def ensure_tuple(x):
+    if isinstance(x, six.string_types):
+        x = (x,)
+    return tuple(x)
+
+
+

--- a/pysnooper/variables.py
+++ b/pysnooper/variables.py
@@ -82,14 +82,3 @@ class Indices(Keys):
         result = deepcopy(self)
         result._slice = item
         return result
-
-
-class Enumerate(Variable):
-    def _keys(self, main_value):
-        return enumerate(main_value)
-
-    def _format_key(self, key):
-        return '<{}>'.format(key[0])
-
-    def _get_value(self, main_value, key):
-        return key[1]

--- a/pysnooper/variables.py
+++ b/pysnooper/variables.py
@@ -1,4 +1,5 @@
 import itertools
+from collections import Mapping, Sequence
 from copy import deepcopy
 
 from .utils import get_shortish_repr, ensure_tuple
@@ -94,16 +95,11 @@ class Indices(Keys):
 
 class Exploded(BaseVariable):
     def _items(self, main_value):
-        typ = main_value.__class__
-
-        def has_method(name):
-            return callable(getattr(typ, name, None))
-
-        cls = Attrs
-        if has_method('__getitem__'):
-            if has_method('keys'):
-                cls = Keys
-            elif has_method('__len__'):
-                cls = Indices
+        if isinstance(main_value, Mapping):
+            cls = Keys
+        elif isinstance(main_value, Sequence):
+            cls = Indices
+        else:
+            cls = Attrs
 
         return cls(self.source, self.exclude)._items(main_value)

--- a/pysnooper/variables.py
+++ b/pysnooper/variables.py
@@ -1,11 +1,12 @@
 import itertools
+from abc import ABC, abstractmethod
 from collections import Mapping, Sequence
 from copy import deepcopy
 
 from . import utils
 
 
-class BaseVariable(object):
+class BaseVariable(ABC):
     def __init__(self, source, exclude=()):
         self.source = source
         self.exclude = utils.ensure_tuple(exclude)
@@ -18,6 +19,7 @@ class BaseVariable(object):
             return ()
         return self._items(main_value)
 
+    @abstractmethod
     def _items(self, key):
         raise NotImplementedError()
 

--- a/pysnooper/variables.py
+++ b/pysnooper/variables.py
@@ -2,13 +2,13 @@ import itertools
 from collections import Mapping, Sequence
 from copy import deepcopy
 
-from .utils import get_shortish_repr, ensure_tuple
+from . import utils
 
 
 class BaseVariable(object):
     def __init__(self, source, exclude=()):
         self.source = source
-        self.exclude = ensure_tuple(exclude)
+        self.exclude = utils.ensure_tuple(exclude)
         self.code = compile(source, '<variable>', 'eval')
 
     def items(self, frame):
@@ -24,7 +24,7 @@ class BaseVariable(object):
 
 class CommonVariable(BaseVariable):
     def _items(self, main_value):
-        result = [(self.source, get_shortish_repr(main_value))]
+        result = [(self.source, utils.get_shortish_repr(main_value))]
         for key in self._safe_keys(main_value):
             try:
                 if key in self.exclude:
@@ -34,7 +34,7 @@ class CommonVariable(BaseVariable):
                 continue
             result.append((
                 '({}){}'.format(self.source, self._format_key(key)),
-                get_shortish_repr(value)
+                utils.get_shortish_repr(value)
             ))
         return result
 
@@ -74,7 +74,7 @@ class Keys(CommonVariable):
         return main_value.keys()
 
     def _format_key(self, key):
-        return '[{}]'.format(get_shortish_repr(key))
+        return '[{}]'.format(utils.get_shortish_repr(key))
 
     def _get_value(self, main_value, key):
         return main_value[key]

--- a/pysnooper/variables.py
+++ b/pysnooper/variables.py
@@ -1,12 +1,13 @@
 import itertools
-from abc import ABC, abstractmethod
+import abc
 from collections import Mapping, Sequence
 from copy import deepcopy
 
 from . import utils
+from . import pycompat
 
 
-class BaseVariable(ABC):
+class BaseVariable(pycompat.ABC):
     def __init__(self, source, exclude=()):
         self.source = source
         self.exclude = utils.ensure_tuple(exclude)
@@ -19,7 +20,7 @@ class BaseVariable(ABC):
             return ()
         return self._items(main_value)
 
-    @abstractmethod
+    @abc.abstractmethod
     def _items(self, key):
         raise NotImplementedError
 

--- a/pysnooper/variables.py
+++ b/pysnooper/variables.py
@@ -1,0 +1,95 @@
+import itertools
+from copy import deepcopy
+
+from .utils import get_shortish_repr, ensure_tuple
+
+
+class Variable(object):
+    def __init__(self, source, exclude=()):
+        self.source = source
+        self.exclude = ensure_tuple(exclude)
+        self.code = compile(source, '<variable>', 'eval')
+
+    def items(self, frame):
+        try:
+            main_value = eval(self.code, frame.f_globals, frame.f_locals)
+        except Exception:
+            return ()
+        result = [(self.source, get_shortish_repr(main_value))]
+        for key in self._safe_keys(main_value):
+            if key in self.exclude:
+                continue
+            try:
+                value = self._get_value(main_value, key)
+            except Exception:
+                continue
+            result.append((
+                '({}){}'.format(self.source, self._format_key(key)),
+                get_shortish_repr(value)
+            ))
+        return result
+
+    def _safe_keys(self, main_value):
+        try:
+            for key in self._keys(main_value):
+                yield key
+        except Exception:
+            pass
+
+    def _keys(self, main_value):
+        return ()
+
+    def _format_key(self, key):
+        raise NotImplementedError()
+
+    def _get_value(self, main_value, key):
+        raise NotImplementedError()
+
+
+class Attrs(Variable):
+    def _keys(self, main_value):
+        return itertools.chain(
+            getattr(main_value, '__dict__', ()),
+            getattr(main_value, '__slots__', ())
+        )
+
+    def _format_key(self, key):
+        return '.' + key
+
+    def _get_value(self, main_value, key):
+        return getattr(main_value, key)
+
+
+class Keys(Variable):
+    def _keys(self, main_value):
+        return main_value.keys()
+
+    def _format_key(self, key):
+        return '[{!r}]'.format(key)
+
+    def _get_value(self, main_value, key):
+        return main_value[key]
+
+
+class Indices(Keys):
+    _slice = slice(None)
+
+    def _keys(self, main_value):
+        return range(len(main_value))[self._slice]
+
+    def __getitem__(self, item):
+        assert isinstance(item, slice)
+        result = deepcopy(self)
+        result._slice = item
+        return result
+
+
+class Enumerate(Variable):
+    def _keys(self, main_value):
+        return enumerate(main_value)
+
+    def _format_key(self, key):
+        return '<{}>'.format(key[0])
+
+    def _get_value(self, main_value, key):
+        return key[1]

--- a/pysnooper/variables.py
+++ b/pysnooper/variables.py
@@ -74,7 +74,7 @@ class Keys(CommonVariable):
         return main_value.keys()
 
     def _format_key(self, key):
-        return '[{!r}]'.format(key)
+        return '[{}]'.format(get_shortish_repr(key))
 
     def _get_value(self, main_value, key):
         return main_value[key]

--- a/pysnooper/variables.py
+++ b/pysnooper/variables.py
@@ -13,7 +13,7 @@ class BaseVariable(object):
 
     def items(self, frame):
         try:
-            main_value = eval(self.code, frame.f_globals, frame.f_locals)
+            main_value = eval(self.code, frame.f_globals or {}, frame.f_locals)
         except Exception:
             return ()
         return self._items(main_value)

--- a/pysnooper/variables.py
+++ b/pysnooper/variables.py
@@ -26,9 +26,9 @@ class CommonVariable(BaseVariable):
     def _items(self, main_value):
         result = [(self.source, get_shortish_repr(main_value))]
         for key in self._safe_keys(main_value):
-            if key in self.exclude:
-                continue
             try:
+                if key in self.exclude:
+                    continue
                 value = self._get_value(main_value, key)
             except Exception:
                 continue

--- a/pysnooper/variables.py
+++ b/pysnooper/variables.py
@@ -21,7 +21,7 @@ class BaseVariable(ABC):
 
     @abstractmethod
     def _items(self, key):
-        raise NotImplementedError()
+        raise NotImplementedError
 
 
 class CommonVariable(BaseVariable):
@@ -51,10 +51,10 @@ class CommonVariable(BaseVariable):
         return ()
 
     def _format_key(self, key):
-        raise NotImplementedError()
+        raise NotImplementedError
 
     def _get_value(self, main_value, key):
-        raise NotImplementedError()
+        raise NotImplementedError
 
 
 class Attrs(CommonVariable):

--- a/pysnooper/variables.py
+++ b/pysnooper/variables.py
@@ -96,7 +96,7 @@ class Indices(Keys):
         return result
 
 
-class Exploded(BaseVariable):
+class Exploding(BaseVariable):
     def _items(self, main_value):
         if isinstance(main_value, Mapping):
             cls = Keys

--- a/tests/test_pysnooper.py
+++ b/tests/test_pysnooper.py
@@ -3,13 +3,12 @@
 
 import io
 import textwrap
-from types import SimpleNamespace
+import types
 
 from python_toolbox import sys_tools, temp_file_tools
 import pytest
 
 import pysnooper
-from pysnooper.variables import Attrs, Keys, Indices
 from .utils import (assert_output, VariableEntry, CallEntry, LineEntry,
                     ReturnEntry, OpcodeEntry, ReturnValueEntry, ExceptionEntry)
 
@@ -127,10 +126,16 @@ def test_variables():
 
 
 def test_exploded_variables():
-    @pysnooper.snoop(exploded_variables='_d _point lst'.split())
+    class Foo:
+        def __init__(self, x, y):
+            self.x = x
+            self.y = y
+
+
+    @pysnooper.snoop(exploded_variables=('_d', '_point', 'lst'))
     def my_function():
         _d = {'a': 1, 'b': 2, 'c': 'ignore'}
-        _point = SimpleNamespace(x=3, y=4)
+        _point = Foo(x=3, y=4)
         lst = [7, 8, 9]
         lst.append(10)
 
@@ -142,6 +147,7 @@ def test_exploded_variables():
     assert_output(
         output,
         (
+            VariableEntry('Foo'),
             CallEntry('def my_function():'),
             LineEntry(),
             VariableEntry("(_d)['a']", '1'),
@@ -175,10 +181,10 @@ def test_variables_classes():
             self.y = 4
 
     @pysnooper.snoop(variables=(
-            Keys('_d', exclude='c'),
-            Attrs('_d'),  # doesn't have attributes
-            Attrs('_s'),
-            Indices('_lst')[-3:],
+            pysnooper.Keys('_d', exclude='c'),
+            pysnooper.Attrs('_d'),  # doesn't have attributes
+            pysnooper.Attrs('_s'),
+            pysnooper.Indices('_lst')[-3:],
     ))
     def my_function():
         _d = {'a': 1, 'b': 2, 'c': 'ignore'}

--- a/tests/test_pysnooper.py
+++ b/tests/test_pysnooper.py
@@ -74,7 +74,7 @@ def test_callable():
 
 
 
-def test_variables():
+def test_watch():
 
     class Foo(object):
         def __init__(self):
@@ -83,7 +83,7 @@ def test_variables():
         def square(self):
             self.x **= 2
 
-    @pysnooper.snoop(variables=(
+    @pysnooper.snoop(watch=(
             'foo.x',
             'io.__name__',
             'len(foo.__dict__["x"] * "abc")',
@@ -125,14 +125,14 @@ def test_variables():
     )
 
 
-def test_exploded_variables():
+def test_watch_explode():
     class Foo:
         def __init__(self, x, y):
             self.x = x
             self.y = y
 
 
-    @pysnooper.snoop(exploded_variables=('_d', '_point', 'lst'))
+    @pysnooper.snoop(watch_explode=('_d', '_point', 'lst'))
     def my_function():
         _d = {'a': 1, 'b': 2, 'c': 'ignore'}
         _point = Foo(x=3, y=4)
@@ -180,7 +180,7 @@ def test_variables_classes():
             self.x = 3
             self.y = 4
 
-    @pysnooper.snoop(variables=(
+    @pysnooper.snoop(watch=(
             pysnooper.Keys('_d', exclude='c'),
             pysnooper.Attrs('_d'),  # doesn't have attributes
             pysnooper.Attrs('_s'),
@@ -221,7 +221,7 @@ def test_variables_classes():
 
 
 
-def test_single_variable_no_comma():
+def test_single_watch_no_comma():
 
     class Foo(object):
         def __init__(self):
@@ -230,7 +230,7 @@ def test_single_variable_no_comma():
         def square(self):
             self.x **= 2
 
-    @pysnooper.snoop(variables='foo')
+    @pysnooper.snoop(watch='foo')
     def my_function():
         foo = Foo()
         for i in range(2):
@@ -376,7 +376,7 @@ def test_method_and_prefix():
         def __init__(self):
             self.x = 2
 
-        @pysnooper.snoop(variables=('self.x',), prefix='ZZZ')
+        @pysnooper.snoop(watch=('self.x',), prefix='ZZZ')
         def square(self):
             foo = 7
             self.x **= 2

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -31,6 +31,20 @@ class _BaseEntry(pysnooper.pycompat.ABC):
     def check(self, s):
         pass
 
+    def __repr__(self):
+        init_arguments = get_function_arguments(self.__init__,
+                                                exclude=('self',))
+        attributes = {
+            key: repr(getattr(self, key)) for key in init_arguments
+                                              if getattr(self, key) is not None
+        }
+        return '%s(%s)' % (
+            type(self).__name__,
+            ', '.join('{key}={value}'.format(**locals()) for key, value
+                                                         in attributes.items())
+        )
+
+
 
 class _BaseValueEntry(_BaseEntry):
     def __init__(self, prefix=''):
@@ -55,19 +69,6 @@ class _BaseValueEntry(_BaseEntry):
         _, preamble, content = match.groups()
         return (self._check_preamble(preamble) and
                                                   self._check_content(content))
-
-    def __repr__(self):
-        init_arguments = get_function_arguments(self.__init__,
-                                                exclude=('self',))
-        attributes = {
-            key: repr(getattr(self, key)) for key in init_arguments
-                                              if getattr(self, key) is not None
-        }
-        return '%s(%s)' % (
-            type(self).__name__,
-            ', '.join('{key}={value}'.format(**locals()) for key, value
-                                                         in attributes.items())
-        )
 
 
 class VariableEntry(_BaseValueEntry):


### PR DESCRIPTION
Closes #59 

Sample usage:

```python
from types import SimpleNamespace

import pysnooper
from pysnooper.variables import Attrs, Indices, Keys, Enumerate


@pysnooper.snoop(variables=(
        Keys('d', exclude='c'),
        Attrs('point'),
        Indices('lst')[-3:],
        Enumerate('s'),
))
def foo():
    d = {'a': 1, 'b': 2, 'c': 'ignore'}
    point = SimpleNamespace(x=3, y=4)
    lst = list(range(1000))
    s = {7, 8, 9}


foo()
```

Output:

```
19:01:11.689207 call        13 def foo():
19:01:11.779673 line        14     d = {'a': 1, 'b': 2, 'c': 'ignore'}
New var:....... (d)['a'] = 1
New var:....... (d)['b'] = 2
New var:....... d = {'a': 1, 'b': 2, 'c': 'ignore'}
19:01:11.872593 line        15     point = SimpleNamespace(x=3, y=4)
New var:....... (point).x = 3
New var:....... (point).y = 4
New var:....... point = namespace(x=3, y=4)
19:01:12.000584 line        16     lst = list(range(1000))
New var:....... (lst)[997] = 997
New var:....... (lst)[998] = 998
New var:....... (lst)[999] = 999
New var:....... lst = [0, 1, 2, 3, 4, 5, ...]
19:01:12.128228 line        17     s = {7, 8, 9}
New var:....... (s)<0> = 8
New var:....... (s)<1> = 9
New var:....... (s)<2> = 7
New var:....... s = {7, 8, 9}
19:01:12.260525 return      17     s = {7, 8, 9}
Return value:.. None
```