### PR TITLE
add usage to package docstring; fixes #83

### DIFF
--- a/pysnooper/__init__.py
+++ b/pysnooper/__init__.py
@@ -1,5 +1,20 @@
 # Copyright 2019 Ram Rachum and collaborators.
 # This program is distributed under the MIT license.
+"""PySnooper - Never use print for debugging again
+
+Usage:
+
+    import pysnooper
+
+    @pysnooper.snoop()
+    def number_to_bits(number):
+        ...
+
+A log will be written to stderr showing the lines executed and variables
+changed in the decorated function.
+
+For more information, see https://github.com/cool-RR/PySnooper
+"""
 
 from .pysnooper import snoop
 from .variables import Attrs, Exploding, Indices, Keys


### PR DESCRIPTION
Aside, does "pysnooper" need to be a package? If it were a module, "pydoc pysnooper" would directly show the docstring of "pysnooper.snoop"; now there's an extra level of indirection.