### PR TITLE
Update README with conda installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,8 +145,16 @@ Start all snoop lines with a prefix, to grep for them easily:
 
 # Installation #
 
+You can install **PySnooper** by:
+
+* pip:
 ```console
 $ pip install pysnooper
+```
+
+* conda with conda-forge channel:
+```console
+$ conda install -c conda-forge pysnooper
 ```
 
 # Advanced Usage #


### PR DESCRIPTION
Hi,

I added the PySnooper to [conda-forge](https://conda-forge.org/) channel. Now, it is possible to install PySnooper with conda as:

```console
$ conda install -c conda-forge pysnooper
```

I think it can contribute by providing a wider access to this excellent Python debugger. I hope it would be appreciated.

By the way, as commented in the other PR I opened here, would you be interested in being included as one of the maintainers of the PySnooper feedstock in conda-forge channel? If you don't want, there is no problem.