### PR TITLE
Preserve the local variables order in the output.

### DIFF
--- a/pysnooper/tracer.py
+++ b/pysnooper/tracer.py
@@ -288,9 +288,7 @@ class Tracer:
             if name not in old_local_reprs:
                 self.write('{indent}{newish_string}{name} = {value_repr}'.format(
                                                                        **locals()))
-
-        for name, value_repr in local_reprs.items():
-            if name in old_local_reprs and old_local_reprs[name] != value_repr:
+            elif old_local_reprs[name] != value_repr:
                 self.write('{indent}Modified var:.. {name} = {value_repr}'.format(
                                                                    **locals()))
 

--- a/pysnooper/tracer.py
+++ b/pysnooper/tracer.py
@@ -19,17 +19,12 @@ ipython_filename_pattern = re.compile('^<ipython-input-([0-9]+)-.*>$')
 
 
 def get_local_reprs(frame, watch=()):
-    result_items = [(key, utils.get_shortish_repr(value)) for key, value
-                                                     in frame.f_locals.items()]
+    result_items = [(key, utils.get_shortish_repr(value)) for key, value in frame.f_locals.items()]
 
     vars_order = frame.f_code.co_varnames + frame.f_code.co_cellvars + frame.f_code.co_freevars
-    result_items.sort(
-        key=lambda key_value: (
-            (vars_order.index(key_value[0]) if key_value[0] in vars_order else float("inf")),
-            key_value[0]
-        )
-    )
+    vars_order += tuple(frame.f_locals.keys())
 
+    result_items.sort(key=lambda key_value: vars_order.index(key_value[0]))
     result = collections.OrderedDict(result_items)
 
     for variable in watch:

--- a/pysnooper/tracer.py
+++ b/pysnooper/tracer.py
@@ -193,7 +193,7 @@ class Tracer:
              v if isinstance(v, BaseVariable) else Exploding(v)
              for v in utils.ensure_tuple(watch_explode)
         ]
-        self.frame_to_local_reprs = collections.OrderedDict()
+        self.frame_to_local_reprs = {}
         self.depth = depth
         self.prefix = prefix
         self.overwrite = overwrite

--- a/pysnooper/tracer.py
+++ b/pysnooper/tracer.py
@@ -19,11 +19,10 @@ ipython_filename_pattern = re.compile('^<ipython-input-([0-9]+)-.*>$')
 
 
 def get_local_reprs(frame, watch=()):
-    result_items = [(key, utils.get_shortish_repr(value)) for key, value in frame.f_locals.items()]
-
     vars_order = frame.f_code.co_varnames + frame.f_code.co_cellvars + frame.f_code.co_freevars
     vars_order += tuple(frame.f_locals.keys())
 
+    result_items = [(key, utils.get_shortish_repr(value)) for key, value in frame.f_locals.items()]
     result_items.sort(key=lambda key_value: vars_order.index(key_value[0]))
     result = collections.OrderedDict(result_items)
 

--- a/pysnooper/tracer.py
+++ b/pysnooper/tracer.py
@@ -19,7 +19,8 @@ ipython_filename_pattern = re.compile('^<ipython-input-([0-9]+)-.*>$')
 
 
 def get_local_reprs(frame, watch=()):
-    vars_order = frame.f_code.co_varnames + frame.f_code.co_cellvars + frame.f_code.co_freevars + tuple(frame.f_locals.keys())
+    code = frame.f_code
+    vars_order = code.co_varnames + code.co_cellvars + code.co_freevars + tuple(frame.f_locals.keys())
 
     result_items = [(key, utils.get_shortish_repr(value)) for key, value in frame.f_locals.items()]
     result_items.sort(key=lambda key_value: vars_order.index(key_value[0]))

--- a/pysnooper/tracer.py
+++ b/pysnooper/tracer.py
@@ -282,23 +282,19 @@ class Tracer:
         self.frame_to_local_reprs[frame] = local_reprs = \
                                        get_local_reprs(frame, watch=self.watch)
 
-        modified_local_reprs = collections.OrderedDict()
-        newish_local_reprs = collections.OrderedDict()
-
-        for key, value in local_reprs.items():
-            if key not in old_local_reprs:
-                newish_local_reprs[key] = value
-            elif old_local_reprs[key] != value:
-                modified_local_reprs[key] = value
-
         newish_string = ('Starting var:.. ' if event == 'call' else
                                                             'New var:....... ')
-        for name, value_repr in newish_local_reprs.items():
-            self.write('{indent}{newish_string}{name} = {value_repr}'.format(
+
+        for name, value_repr in local_reprs.items():
+            if name not in old_local_reprs:
+                self.write('{indent}{newish_string}{name} = {value_repr}'.format(
+                                                                       **locals()))
+
+        for name, value_repr in local_reprs.items():
+            if name in old_local_reprs and old_local_reprs[name] != value_repr:
+                self.write('{indent}Modified var:.. {name} = {value_repr}'.format(
                                                                    **locals()))
-        for name, value_repr in modified_local_reprs.items():
-            self.write('{indent}Modified var:.. {name} = {value_repr}'.format(
-                                                                   **locals()))
+
         #                                                                     #
         ### Finished newish and modified variables. ###########################
 

--- a/pysnooper/tracer.py
+++ b/pysnooper/tracer.py
@@ -19,13 +19,14 @@ ipython_filename_pattern = re.compile('^<ipython-input-([0-9]+)-.*>$')
 
 
 def get_local_reprs(frame, watch=()):
+    var_names = frame.f_code.co_varnames + frame.f_code.co_cellvars
     result = collections.OrderedDict(
         (key, utils.get_shortish_repr(frame.f_locals[key]))
-        for key in frame.f_code.co_varnames if key in frame.f_locals
+        for key in var_names if key in frame.f_locals
     )
 
-    result.update(sorted((key, utils.get_shortish_repr(frame.f_locals[key]))
-                  for key in set(frame.f_locals) - set(frame.f_code.co_varnames)))
+    result.update((key, utils.get_shortish_repr(frame.f_locals[key]))
+                  for key in frame.f_code.co_freevars)
 
     for variable in watch:
         result.update(sorted(variable.items(frame)))

--- a/pysnooper/tracer.py
+++ b/pysnooper/tracer.py
@@ -24,8 +24,11 @@ def get_local_reprs(frame, watch=()):
         for key in frame.f_code.co_varnames if key in frame.f_locals
     )
 
+    result.update(sorted((key, utils.get_shortish_repr(frame.f_locals[key]))
+                  for key in set(frame.f_locals) - set(frame.f_code.co_varnames)))
+
     for variable in watch:
-        result.update(variable.items(frame))
+        result.update(sorted(variable.items(frame)))
     return result
 
 

--- a/pysnooper/tracer.py
+++ b/pysnooper/tracer.py
@@ -19,14 +19,18 @@ ipython_filename_pattern = re.compile('^<ipython-input-([0-9]+)-.*>$')
 
 
 def get_local_reprs(frame, watch=()):
-    var_names = frame.f_code.co_varnames + frame.f_code.co_cellvars
-    result = collections.OrderedDict(
-        (key, utils.get_shortish_repr(frame.f_locals[key]))
-        for key in var_names if key in frame.f_locals
+    result_items = [(key, utils.get_shortish_repr(value)) for key, value
+                                                     in frame.f_locals.items()]
+
+    vars_order = frame.f_code.co_varnames + frame.f_code.co_cellvars + frame.f_code.co_freevars
+    result_items.sort(
+        key=lambda key_value: (
+            (vars_order.index(key_value[0]) if key_value[0] in vars_order else float("inf")),
+            key_value[0]
+        )
     )
 
-    result.update((key, utils.get_shortish_repr(frame.f_locals[key]))
-                  for key in frame.f_code.co_freevars)
+    result = collections.OrderedDict(result_items)
 
     for variable in watch:
         result.update(sorted(variable.items(frame)))

--- a/pysnooper/tracer.py
+++ b/pysnooper/tracer.py
@@ -19,8 +19,11 @@ ipython_filename_pattern = re.compile('^<ipython-input-([0-9]+)-.*>$')
 
 
 def get_local_reprs(frame, watch=()):
-    result = {key: utils.get_shortish_repr(value) for key, value
-                                                     in frame.f_locals.items()}
+    result = collections.OrderedDict(
+        (key, utils.get_shortish_repr(frame.f_locals[key]))
+        for key in frame.f_code.co_varnames if key in frame.f_locals
+    )
+
     for variable in watch:
         result.update(variable.items(frame))
     return result
@@ -182,7 +185,7 @@ class Tracer:
              v if isinstance(v, BaseVariable) else Exploding(v)
              for v in utils.ensure_tuple(watch_explode)
         ]
-        self.frame_to_local_reprs = collections.defaultdict(lambda: {})
+        self.frame_to_local_reprs = collections.OrderedDict()
         self.depth = depth
         self.prefix = prefix
         self.overwrite = overwrite
@@ -272,12 +275,12 @@ class Tracer:
 
         ### Reporting newish and modified variables: ##########################
         #                                                                     #
-        old_local_reprs = self.frame_to_local_reprs[frame]
+        old_local_reprs = self.frame_to_local_reprs.get(frame, {})
         self.frame_to_local_reprs[frame] = local_reprs = \
                                        get_local_reprs(frame, watch=self.watch)
 
-        modified_local_reprs = {}
-        newish_local_reprs = {}
+        modified_local_reprs = collections.OrderedDict()
+        newish_local_reprs = collections.OrderedDict()
 
         for key, value in local_reprs.items():
             if key not in old_local_reprs:
@@ -287,10 +290,10 @@ class Tracer:
 
         newish_string = ('Starting var:.. ' if event == 'call' else
                                                             'New var:....... ')
-        for name, value_repr in sorted(newish_local_reprs.items()):
+        for name, value_repr in newish_local_reprs.items():
             self.write('{indent}{newish_string}{name} = {value_repr}'.format(
                                                                    **locals()))
-        for name, value_repr in sorted(modified_local_reprs.items()):
+        for name, value_repr in modified_local_reprs.items():
             self.write('{indent}Modified var:.. {name} = {value_repr}'.format(
                                                                    **locals()))
         #                                                                     #

--- a/pysnooper/tracer.py
+++ b/pysnooper/tracer.py
@@ -19,8 +19,7 @@ ipython_filename_pattern = re.compile('^<ipython-input-([0-9]+)-.*>$')
 
 
 def get_local_reprs(frame, watch=()):
-    vars_order = frame.f_code.co_varnames + frame.f_code.co_cellvars + frame.f_code.co_freevars
-    vars_order += tuple(frame.f_locals.keys())
+    vars_order = frame.f_code.co_varnames + frame.f_code.co_cellvars + frame.f_code.co_freevars + tuple(frame.f_locals.keys())
 
     result_items = [(key, utils.get_shortish_repr(value)) for key, value in frame.f_locals.items()]
     result_items.sort(key=lambda key_value: vars_order.index(key_value[0]))

--- a/tests/test_pysnooper.py
+++ b/tests/test_pysnooper.py
@@ -986,6 +986,10 @@ def test_var_order():
     string_io = io.StringIO()
 
     def f(one, two, three, four):
+        five = None
+        six = None
+        seven = None
+
         five, six, seven = 5, 6, 7
 
     with pysnooper.snoop(string_io, depth=2):
@@ -1005,6 +1009,12 @@ def test_var_order():
             VariableEntry("four", "4"),
 
             CallEntry('def f(one, two, three, four):'),
+            LineEntry(),
+            VariableEntry("five"),
+            LineEntry(),
+            VariableEntry("six"),
+            LineEntry(),
+            VariableEntry("seven"),
             LineEntry(),
             VariableEntry("five", "5"),
             VariableEntry("six", "6"),

--- a/tests/test_pysnooper.py
+++ b/tests/test_pysnooper.py
@@ -276,8 +276,8 @@ def test_watch_explode():
             VariableEntry('(lst + [])[2]', '9'),
             VariableEntry('lst + []'),
             LineEntry(),
-            VariableEntry('(lst + [])[3]', '10'),
             VariableEntry('lst'),
+            VariableEntry('(lst + [])[3]', '10'),
             VariableEntry('lst + []'),
             ReturnEntry(),
             ReturnValueEntry('None')

--- a/tests/test_pysnooper.py
+++ b/tests/test_pysnooper.py
@@ -270,10 +270,10 @@ def test_watch_explode():
             VariableEntry('_point.x', '3'),
             VariableEntry('_point.y', '4'),
             LineEntry(),
+            VariableEntry('lst'),
             VariableEntry('(lst + [])[0]', '7'),
             VariableEntry('(lst + [])[1]', '8'),
             VariableEntry('(lst + [])[2]', '9'),
-            VariableEntry('lst'),
             VariableEntry('lst + []'),
             LineEntry(),
             VariableEntry('(lst + [])[3]', '10'),
@@ -790,23 +790,23 @@ def test_with_block():
         output,
         (
             # In first with
+            VariableEntry('x', '2'),
             VariableEntry('bar1'),
             VariableEntry('bar2'),
             VariableEntry('bar3'),
             VariableEntry('foo'),
             VariableEntry('qux'),
             VariableEntry('snoop'),
-            VariableEntry('x', '2'),
             LineEntry('foo(x - 1)'),
 
             # In with in recursive call
+            VariableEntry('x', '1'),
             VariableEntry('bar1'),
             VariableEntry('bar2'),
             VariableEntry('bar3'),
             VariableEntry('foo'),
             VariableEntry('qux'),
             VariableEntry('snoop'),
-            VariableEntry('x', '1'),
             LineEntry('foo(x - 1)'),
 
             # Call to bar1 from if block outside with

--- a/tests/test_pysnooper.py
+++ b/tests/test_pysnooper.py
@@ -982,6 +982,39 @@ def test_cellvars():
         )
     )
 
+def test_var_order():
+    string_io = io.StringIO()
+
+    def f(one, two, three, four):
+        five, six, seven = 5, 6, 7
+
+    with pysnooper.snoop(string_io, depth=2):
+        result = f(1, 2, 3, 4)
+
+    output = string_io.getvalue()
+    assert_output(
+        output,
+        (
+            VariableEntry(),
+            VariableEntry(),
+
+            LineEntry('result = f(1, 2, 3, 4)'),
+            VariableEntry("one", "1"),
+            VariableEntry("two", "2"),
+            VariableEntry("three", "3"),
+            VariableEntry("four", "4"),
+
+            CallEntry('def f(one, two, three, four):'),
+            LineEntry(),
+            VariableEntry("five", "5"),
+            VariableEntry("six", "6"),
+            VariableEntry("seven", "7"),
+            ReturnEntry(),
+            ReturnValueEntry(),
+        )
+    )
+
+
 
 def test_truncate():
     max_length = 20


### PR DESCRIPTION
Write the variables in the declare order, instead of the alphabetical one.

This causes function arguments to be printed in the declare order.
All watched variables are outputted after declared ones.

Example code:

```python
import pysnooper

@pysnooper.snoop()
def f(one, two, three, four):
    five, six, seven = 5, 6, 7

f(1, 2, 3, 4)
```

Before:
```
Starting var:.. four = 4
Starting var:.. one = 1
Starting var:.. three = 3
Starting var:.. two = 2
03:22:33.398756 call         4 def f(one, two, three, four):
03:22:33.398987 line         5     five, six, seven = 5, 6, 7
New var:....... five = 5
New var:....... seven = 7
New var:....... six = 6
03:22:33.399147 return       5     five, six, seven = 5, 6, 7
Return value:.. None
```

After:
```
Starting var:.. one = 1
Starting var:.. two = 2
Starting var:.. three = 3
Starting var:.. four = 4
03:23:22.381525 call         4 def f(one, two, three, four):
03:23:22.381743 line         5     five, six, seven = 5, 6, 7
New var:....... five = 5
New var:....... six = 6
New var:....... seven = 7
03:23:22.381872 return       5     five, six, seven = 5, 6, 7
Return value:.. None
```