### PR TITLE
Log exceptions nicely

### DIFF
--- a/pysnooper/tracer.py
+++ b/pysnooper/tracer.py
@@ -339,10 +339,13 @@ class Tracer:
         # If a call ends due to an exception, we still get a 'return' event
         # with arg = None. This seems to be the only way to tell the difference
         # https://stackoverflow.com/a/12800909/2482744
+        code_byte = frame.f_code.co_code[frame.f_lasti]
+        if not isinstance(code_byte, int):
+            code_byte = ord(code_byte)
         ended_by_exception = (
                 event == 'return'
                 and arg is None
-                and (opcode.opname[frame.f_code.co_code[frame.f_lasti]]
+                and (opcode.opname[code_byte]
                      not in ('RETURN_VALUE', 'YIELD_VALUE'))
         )
 

--- a/pysnooper/utils.py
+++ b/pysnooper/utils.py
@@ -7,6 +7,7 @@ from .pycompat import ABC
 from .third_party import six
 
 MAX_VARIABLE_LENGTH = 100
+MAX_EXCEPTION_LENGTH = 200
 
 def _check_methods(C, *methods):
     mro = C.__mro__

--- a/tests/samples/exception.py
+++ b/tests/samples/exception.py
@@ -8,8 +8,8 @@ def foo():
 def bar():
     try:
         foo()
-    except Exception as e:
-        str(e)
+    except Exception:
+        str(1)
         raise
 
 
@@ -35,9 +35,8 @@ expected_output = '''
         Call ended by exception
     12:18:08.018494 exception   10         foo()
     TypeError: bad
-    12:18:08.018545 line        11     except Exception as e:
-    New var:....... e = TypeError('bad',)
-    12:18:08.018597 line        12         str(e)
+    12:26:33.942623 line        11     except Exception:
+    12:26:33.942674 line        12         str(1)
     12:18:08.018655 line        13         raise
     Call ended by exception
 12:18:08.018718 exception   19         bar()

--- a/tests/samples/exception.py
+++ b/tests/samples/exception.py
@@ -1,0 +1,49 @@
+import pysnooper
+
+
+def foo():
+    raise TypeError('bad')
+
+
+def bar():
+    try:
+        foo()
+    except Exception as e:
+        str(e)
+        raise
+
+
+@pysnooper.snoop(depth=3)
+def main():
+    try:
+        bar()
+    except:
+        pass
+
+
+expected_output = '''
+12:18:08.017782 call        17 def main():
+12:18:08.018142 line        18     try:
+12:18:08.018181 line        19         bar()
+    12:18:08.018223 call         8 def bar():
+    12:18:08.018260 line         9     try:
+    12:18:08.018293 line        10         foo()
+        12:18:08.018329 call         4 def foo():
+        12:18:08.018364 line         5     raise TypeError('bad')
+        12:18:08.018396 exception    5     raise TypeError('bad')
+        TypeError: bad
+        Call ended by exception
+    12:18:08.018494 exception   10         foo()
+    TypeError: bad
+    12:18:08.018545 line        11     except Exception as e:
+    New var:....... e = TypeError('bad',)
+    12:18:08.018597 line        12         str(e)
+    12:18:08.018655 line        13         raise
+    Call ended by exception
+12:18:08.018718 exception   19         bar()
+TypeError: bad
+12:18:08.018761 line        20     except:
+12:18:08.018787 line        21         pass
+12:18:08.018813 return      21         pass
+Return value:.. None
+'''

--- a/tests/test_pysnooper.py
+++ b/tests/test_pysnooper.py
@@ -938,3 +938,8 @@ def test_indentation():
     from .samples import indentation, recursion
     assert_sample_output(indentation)
     assert_sample_output(recursion)
+
+
+def test_exception():
+    from .samples import exception
+    assert_sample_output(exception)


### PR DESCRIPTION
Script:

```python
import pysnooper


@pysnooper.snoop()
def foo():
    1 / 0


@pysnooper.snoop()
def bar():
    foo()


bar()
```

Before:

```
08:58:06.538289 call        10 def bar():
08:58:06.538506 line        11     foo()
    08:58:06.538567 call         5 def foo():
    08:58:06.538613 line         6     1 / 0
    08:58:06.538650 exception    6     1 / 0
    08:58:06.538685 return       6     1 / 0
    Return value:.. None
08:58:06.538751 exception   11     foo()
08:58:06.538786 return      11     foo()
Return value:.. None
Traceback (most recent call last):
```

After:

```
09:04:08.579983 call        10 def bar():
09:04:08.580215 line        11     foo()
    09:04:08.580272 call         5 def foo():
    09:04:08.580315 line         6     1 / 0
    09:04:08.580352 exception    6     1 / 0
    ZeroDivisionError: division by zero
    Call ended by exception
09:04:08.580491 exception   11     foo()
ZeroDivisionError: division by zero
Call ended by exception
Traceback (most recent call last):
```