### PR TITLE
Allow using with block without parentheses

### DIFF
--- a/tests/samples/with_no_parentheses.py
+++ b/tests/samples/with_no_parentheses.py
@@ -1,0 +1,17 @@
+import pysnooper
+
+
+def main():
+    x = 1
+    with pysnooper.snoop:
+        y = x + 1
+        z = y + 2
+    str(z)
+
+
+expected_output = '''
+New var:....... x = 1
+20:38:44.712343 line         7         y = x + 1
+New var:....... y = 2
+20:38:44.712700 line         8         z = y + 2
+'''

--- a/tests/test_pysnooper.py
+++ b/tests/test_pysnooper.py
@@ -1050,6 +1050,11 @@ def test_exception():
     assert_sample_output(exception)
 
 
+def test_with_no_parentheses():
+    from .samples import with_no_parentheses
+    assert_sample_output(with_no_parentheses)
+
+
 def test_generator():
     string_io = io.StringIO()
     original_tracer = sys.gettrace()


### PR DESCRIPTION
This lets you write:

    with pysnooper.snoop:

It's a pretty silly idea, and it's fine if you reject it, but it was kinda fun to write.