### PR TITLE
Add log function

### DIFF
--- a/pysnooper/__init__.py
+++ b/pysnooper/__init__.py
@@ -17,7 +17,7 @@ changed in the decorated function.
 For more information, see https://github.com/cool-RR/PySnooper
 '''
 
-from .tracer import Tracer as snoop
+from .tracer import Tracer as snoop, log
 from .variables import Attrs, Exploding, Indices, Keys
 import collections
 

--- a/pysnooper/tracer.py
+++ b/pysnooper/tracer.py
@@ -4,6 +4,7 @@
 import functools
 import inspect
 import opcode
+import os
 import sys
 import re
 import collections
@@ -392,3 +393,28 @@ class Tracer:
                        format(**locals()))
 
         return self.trace
+
+
+def log(*args):
+    trace = sys.gettrace()
+    tracer = getattr(trace, '__self__', None)
+    if not isinstance(tracer, Tracer):
+        return  # pysnooper is not active
+
+    frame = inspect.currentframe().f_back
+
+    filename = os.path.basename(frame.f_code.co_filename)
+    if filename.endswith('.pyc'):
+        filename = filename[:-1]
+
+    function_name = frame.f_code.co_name
+    line_no = frame.f_lineno
+
+    for arg in args:
+        tracer.write('Log from {filename} - {function_name} - {line_no}: {arg}'
+                     .format(**locals()))
+    
+    if len(args) == 1:
+        return args[0]
+    else:
+        return args

--- a/tests/samples/log.py
+++ b/tests/samples/log.py
@@ -1,0 +1,24 @@
+from pysnooper import log, snoop
+
+
+@snoop()
+def main():
+    x = 4
+    y = 2 + log(x * 3)
+    log(pow(*log(x + 1, y + 1)))
+
+
+expected_output = '''
+21:11:41.664281 call         5 def main():
+21:11:41.664487 line         6     x = 4
+New var:....... x = 4
+21:11:41.664548 line         7     y = 2 + log(x * 3)
+Log from log.py - main - 7: 12
+New var:....... y = 14
+21:11:41.664639 line         8     log(pow(*log(x + 1, y + 1)))
+Log from log.py - main - 8: 5
+Log from log.py - main - 8: 15
+Log from log.py - main - 8: 30517578125
+21:11:41.664746 return       8     log(pow(*log(x + 1, y + 1)))
+Return value:.. None
+'''

--- a/tests/test_pysnooper.py
+++ b/tests/test_pysnooper.py
@@ -1050,6 +1050,11 @@ def test_exception():
     assert_sample_output(exception)
 
 
+def test_log():
+    from .samples import log
+    assert_sample_output(log)
+
+
 def test_generator():
     string_io = io.StringIO()
     original_tracer = sys.gettrace()


### PR DESCRIPTION
I know this library is against print style debugging, but sometimes it has its uses. This helps when the usual pysnooper methods are not ideal. For example:

1. To see a single full value, as in #104. This is more convenient than changing MAX_VARIABLE_LENGTH and doesn't globally make the output more verbose.
2. To see just one value without all the other stuff from `snoop`. Even using `with` on a single line can print out a bunch of irrelevant variables. This can be used in places where there is no decorator or block.
3. To see a value that doesn't have a local variable, without having to rearrange the code and invent a temporary variable. Like the libraries q and icecream, this lets the arguments pass through for minimal code disruption. It's also good for people who are tired and used to print debugging so they don't think of adding a local variable.
4. To see a value just once, if evaluating its repr every line is terrible for performance or seeing every modification to its value would be disruptive.

The main advantage over `print` is that this is combined with the other output nicely, no matter the output method.