### PR TITLE
Remember state of the local vars beforehand

### DIFF
--- a/pysnooper/tracer.py
+++ b/pysnooper/tracer.py
@@ -247,6 +247,8 @@ class Tracer:
             calling_frame.f_trace = self.trace
             self.target_frames.add(calling_frame)
 
+        self.frame_to_local_reprs[calling_frame] = get_local_reprs(calling_frame)
+
         stack = self.thread_local.__dict__.setdefault('original_trace_functions', [])
         stack.append(sys.gettrace())
         sys.settrace(self.trace)
@@ -269,7 +271,6 @@ class Tracer:
 
 
     def trace(self, frame, event, arg):
-
         ### Checking whether we should trace this line: #######################
         #                                                                     #
         # We should trace this line either if it's in the decorated function,

--- a/tests/test_pysnooper.py
+++ b/tests/test_pysnooper.py
@@ -791,23 +791,9 @@ def test_with_block():
         output,
         (
             # In first with
-            VariableEntry('x', '2'),
-            VariableEntry('bar1'),
-            VariableEntry('bar2'),
-            VariableEntry('bar3'),
-            VariableEntry('foo'),
-            VariableEntry('qux'),
-            VariableEntry('snoop'),
             LineEntry('foo(x - 1)'),
 
             # In with in recursive call
-            VariableEntry('x', '1'),
-            VariableEntry('bar1'),
-            VariableEntry('bar2'),
-            VariableEntry('bar3'),
-            VariableEntry('foo'),
-            VariableEntry('qux'),
-            VariableEntry('snoop'),
             LineEntry('foo(x - 1)'),
 
             # Call to bar1 from if block outside with
@@ -895,9 +881,6 @@ def test_with_block_depth():
     assert_output(
         output,
         (
-            VariableEntry(),
-            VariableEntry(),
-            VariableEntry(),
             LineEntry('result1 = f2(x1)'),
 
             VariableEntry(),
@@ -946,9 +929,6 @@ def test_cellvars():
     assert_output(
         output,
         (
-            VariableEntry(),
-            VariableEntry(),
-            VariableEntry(),
             LineEntry('result1 = f2(a)'),
 
             VariableEntry(),
@@ -1000,9 +980,6 @@ def test_var_order():
     assert_output(
         output,
         (
-            VariableEntry(),
-            VariableEntry(),
-
             LineEntry('result = f(1, 2, 3, 4)'),
             VariableEntry("one", "1"),
             VariableEntry("two", "2"),


### PR DESCRIPTION
Now the local variables state is examined when the first callback fires. This can be too late, when the variables were created earlier, before the call. For example this code:
```python
import pysnooper
import sys

class C:
    pass

def f():
    pass

a = 1

with pysnooper.snoop(depth=2):
    2 + 2
```

produces this output
```
New var:....... __name__ = '__main__'
New var:....... __doc__ = None
New var:....... __package__ = None
New var:....... __loader__ = <_frozen_importlib_external.SourceFileLoader object at 0x7f015d3adfd0>
New var:....... __spec__ = None
New var:....... __annotations__ = {}
New var:....... __builtins__ = <module 'builtins' (built-in)>
New var:....... __file__ = 'q.py'
New var:....... __cached__ = None
New var:....... pysnooper = <module 'pysnooper' from '/home/bay/tmp/249_pysnooper/PySnooper/pysnooper/__init__.py'>
New var:....... sys = <module 'sys' (built-in)>
New var:....... C = <class '__main__.C'>
New var:....... f = <function f at 0x7f015d3e61e0>
New var:....... a = 1
00:51:25.580167 line        14     2 + 2
```
Here we can see functions, classes, modules, and special variables, declared earlier.

The idea of this one-line patch is to remember the local variables state before the first call, in the \_\_enter\_\_ function:
```
        self.frame_to_local_reprs[calling_frame] = get_local_reprs(calling_frame)
```

This adds the symmetry with the \_\_exit\_\_  function, because it contains
```
        self.frame_to_local_reprs.pop(calling_frame, None)
```
and also solves the problem:
```
00:51:43.395931 line        14     2 + 2
```