### PR TITLE
Allow using PySnooper as a command line program

### DIFF
--- a/pysnooper/__main__.py
+++ b/pysnooper/__main__.py
@@ -1,0 +1,40 @@
+"""Run script under PySnooper"""
+
+from subprocess import run
+from argparse import ArgumentParser, FileType
+from sys import executable
+from os import environ, pathsep
+from tempfile import mkdtemp
+
+
+code = '''
+import pysnooper
+
+
+pysnooper.snoop().__enter__()
+'''
+
+
+def main():
+    parser = ArgumentParser(description=__doc__)
+    parser.add_argument('script', help='python script', type=FileType('r'))
+    args, rest = parser.parse_known_args()
+
+    root = mkdtemp()
+    with open(f'{root}/sitecustomize.py', 'w') as out:
+        out.write(code)
+
+    env = environ.copy()
+    pypath = env.get('PYTHONPATH', '')
+    if pypath:
+        pypath = f'{root}{pathsep}{pypath}'
+    else:
+        pypath = root
+    env['PYTHONPATH'] = pypath
+
+    cmd = [executable, args.script.name] + rest
+    run(cmd, env=env)
+
+
+if __name__ == '__main__':
+    main()

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,11 @@ setuptools.setup(
             'pytest',
         },
     },
+    entry_points={
+        'console_scripts': [
+            'pysnooper = pysnooper.__main__:main',
+        ],
+    },
     classifiers=[
         'Environment :: Console',
         'Intended Audience :: Developers',

--- a/tests/test_script.py
+++ b/tests/test_script.py
@@ -1,0 +1,45 @@
+from subprocess import Popen, PIPE
+from sys import executable
+from tempfile import NamedTemporaryFile
+
+
+py_code = '''
+def sub(a, b):
+    return a - b
+
+
+val = sub(1, 7)
+print('val =', val)
+'''
+
+
+def run_pysnooper(options=None):
+    tmp = NamedTemporaryFile()
+    tmp.write(py_code.encode('ascii'))
+    tmp.flush()
+
+    # pysnooper emits output to stderr
+    cmd = [executable, '-m', 'pysnooper']
+    if options:
+        cmd += options
+    cmd += [tmp.name]
+    proc = Popen(cmd, stderr=PIPE)
+    assert proc.wait() == 0, 'error running pysnooper'
+
+    return proc.stderr.read().decode('utf-8')
+
+
+def test_script():
+    out = run_pysnooper()
+    for line in py_code.splitlines():
+        assert line in out, '{!r} not found in output'.format(line)
+
+
+def test_prefix():
+    prefix = 'TEST_PYSNOOPR:'
+    out = run_pysnooper(['--prefix', prefix])
+    for line in out.splitlines():
+        assert out.startswith(prefix), line
+
+
+# TODO: test thread info


### PR DESCRIPTION
A POC for running pysnooper as an external command (e.g. `pysnooper /path/to/script.py`)

The script will create `sitecustomize.py` script and will add it first in `PYTHONPATH`.