### PR TITLE
Feature/normalize output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ build/
 
 .coverage
 htmlcov
+/venv/
+.idea

--- a/pysnooper/tracer.py
+++ b/pysnooper/tracer.py
@@ -15,9 +15,9 @@ import traceback
 
 from .variables import CommonVariable, Exploding, BaseVariable
 from . import utils, pycompat
+
 if pycompat.PY2:
     from io import open
-
 
 ipython_filename_pattern = re.compile('^<ipython-input-([0-9]+)-.*>$')
 
@@ -73,7 +73,7 @@ def get_path_and_source_from_frame(frame):
                 import IPython
                 ipython_shell = IPython.get_ipython()
                 ((_, _, source_chunk),) = ipython_shell.history_manager. \
-                                  get_range(0, entry_number, entry_number + 1)
+                    get_range(0, entry_number, entry_number + 1)
                 source = source_chunk.splitlines()
             except Exception:
                 pass
@@ -148,6 +148,7 @@ class FileWriter(object):
 thread_global = threading.local()
 DISABLED = bool(os.getenv('PYSNOOPER_DISABLED', ''))
 
+
 class Tracer:
     '''
     Snoop on the function, writing everything it's doing to stderr.
@@ -199,18 +200,19 @@ class Tracer:
     You can also use `max_variable_length=None` to never truncate them.
 
     '''
+
     def __init__(self, output=None, watch=(), watch_explode=(), depth=1,
                  prefix='', overwrite=False, thread_info=False, custom_repr=(),
                  max_variable_length=100):
         self._write = get_write_function(output, overwrite)
 
         self.watch = [
-            v if isinstance(v, BaseVariable) else CommonVariable(v)
-            for v in utils.ensure_tuple(watch)
-         ] + [
-             v if isinstance(v, BaseVariable) else Exploding(v)
-             for v in utils.ensure_tuple(watch_explode)
-        ]
+                         v if isinstance(v, BaseVariable) else CommonVariable(v)
+                         for v in utils.ensure_tuple(watch)
+                     ] + [
+                         v if isinstance(v, BaseVariable) else Exploding(v)
+                         for v in utils.ensure_tuple(watch_explode)
+                     ]
         self.frame_to_local_reprs = {}
         self.depth = depth
         self.prefix = prefix
@@ -220,8 +222,9 @@ class Tracer:
         self.target_codes = set()
         self.target_frames = set()
         self.thread_local = threading.local()
-        if len(custom_repr) == 2 and not all(isinstance(x,
-                      pycompat.collections_abc.Iterable) for x in custom_repr):
+        if len(custom_repr) == 2 and not all(
+                isinstance(x, pycompat.collections_abc.Iterable) for x in custom_repr
+        ):
             custom_repr = (custom_repr,)
         self.custom_repr = custom_repr
         self.last_source_path = None
@@ -292,7 +295,7 @@ class Tracer:
             self.target_frames.add(calling_frame)
 
         stack = self.thread_local.__dict__.setdefault(
-            'original_trace_functions', []
+                'original_trace_functions', []
         )
         stack.append(sys.gettrace())
         sys.settrace(self.trace)
@@ -363,31 +366,30 @@ class Tracer:
         if self.thread_info:
             current_thread = threading.current_thread()
             thread_info = "{ident}-{name} ".format(
-                ident=current_thread.ident, name=current_thread.getName())
+                    ident=current_thread.ident, name=current_thread.getName())
         thread_info = self.set_thread_info_padding(thread_info)
 
         ### Reporting newish and modified variables: ##########################
         #                                                                     #
         old_local_reprs = self.frame_to_local_reprs.get(frame, {})
         self.frame_to_local_reprs[frame] = local_reprs = \
-                                       get_local_reprs(frame,
-                                                       watch=self.watch, custom_repr=self.custom_repr,
-                                                       max_length=self.max_variable_length)
+            get_local_reprs(frame,
+                            watch=self.watch, custom_repr=self.custom_repr,
+                            max_length=self.max_variable_length)
 
         newish_string = ('Starting var:.. ' if event == 'call' else
-                                                            'New var:....... ')
+                         'New var:....... ')
 
         for name, value_repr in local_reprs.items():
             if name not in old_local_reprs:
                 self.write('{indent}{newish_string}{name} = {value_repr}'.format(
-                                                                       **locals()))
+                        **locals()))
             elif old_local_reprs[name] != value_repr:
                 self.write('{indent}Modified var:.. {name} = {value_repr}'.format(
-                                                                   **locals()))
+                        **locals()))
 
         #                                                                     #
         ### Finished newish and modified variables. ###########################
-
 
         ### Dealing with misplaced function definition: #######################
         #                                                                     #

--- a/pysnooper/tracer.py
+++ b/pysnooper/tracer.py
@@ -34,7 +34,7 @@ def get_local_reprs(frame, watch=(), custom_repr=(), max_length=None, normalize=
     result = collections.OrderedDict(result_items)
 
     for variable in watch:
-        result.update(sorted(variable.items(frame)))
+        result.update(sorted(variable.items(frame, normalize)))
     return result
 
 

--- a/pysnooper/utils.py
+++ b/pysnooper/utils.py
@@ -55,6 +55,9 @@ def get_repr_function(item, custom_repr):
     return repr
 
 
+def normalize_repr(item_repr):
+    return item_repr.partition(' at')[0]
+
 def get_shortish_repr(item, custom_repr=(), max_length=None):
     repr_function = get_repr_function(item, custom_repr)
     try:

--- a/pysnooper/utils.py
+++ b/pysnooper/utils.py
@@ -2,6 +2,7 @@
 # This program is distributed under the MIT license.
 
 import abc
+import re
 
 import sys
 from .pycompat import ABC, string_types, collections_abc
@@ -54,20 +55,23 @@ def get_repr_function(item, custom_repr):
     return repr
 
 
+DEFAULT_REPR_RE = re.compile(r' at 0x[a-f0-9A-F]{4,}')
+
+
 def normalize_repr(item_repr):
-    parts = item_repr.partition(' at')
-    if parts[1]:
-        return parts[0] + '>'
-    return parts[0]
+    """Remove memory address (0x...) from a default python repr"""
+    return DEFAULT_REPR_RE.sub('', item_repr)
 
 
-def get_shortish_repr(item, custom_repr=(), max_length=None):
+def get_shortish_repr(item, custom_repr=(), max_length=None, normalize=False):
     repr_function = get_repr_function(item, custom_repr)
     try:
         r = repr_function(item)
     except Exception:
         r = 'REPR FAILED'
     r = r.replace('\r', '').replace('\n', '')
+    if normalize:
+        r = normalize_repr(r)
     if max_length:
         r = truncate(r, max_length)
     return r

--- a/pysnooper/utils.py
+++ b/pysnooper/utils.py
@@ -6,6 +6,7 @@ import abc
 import sys
 from .pycompat import ABC, string_types, collections_abc
 
+
 def _check_methods(C, *methods):
     mro = C.__mro__
     for method in methods:
@@ -31,18 +32,16 @@ class WritableStream(ABC):
         return NotImplemented
 
 
-
 file_reading_errors = (
     IOError,
     OSError,
-    ValueError # IronPython weirdness.
+    ValueError  # IronPython weirdness.
 )
-
 
 
 def shitcode(s):
     return ''.join(
-        (c if (0 < ord(c) < 256) else '?') for c in s
+            (c if (0 < ord(c) < 256) else '?') for c in s
     )
 
 
@@ -56,7 +55,11 @@ def get_repr_function(item, custom_repr):
 
 
 def normalize_repr(item_repr):
-    return item_repr.partition(' at')[0]
+    parts = item_repr.partition(' at')
+    if parts[1]:
+        return parts[0] + '>'
+    return parts[0]
+
 
 def get_shortish_repr(item, custom_repr=(), max_length=None):
     repr_function = get_repr_function(item, custom_repr)
@@ -81,10 +84,7 @@ def truncate(string, max_length):
 
 def ensure_tuple(x):
     if isinstance(x, collections_abc.Iterable) and \
-                                               not isinstance(x, string_types):
+            not isinstance(x, string_types):
         return tuple(x)
     else:
         return (x,)
-
-
-

--- a/tests/test_pysnooper.py
+++ b/tests/test_pysnooper.py
@@ -32,24 +32,23 @@ def test_string_io():
     assert result == 15
     output = string_io.getvalue()
     assert_output(
-        output,
-        (
-            SourcePathEntry(),
-            VariableEntry('foo', value_regex="u?'baba'"),
-            CallEntry('def my_function(foo):'),
-            LineEntry('x = 7'),
-            VariableEntry('x', '7'),
-            LineEntry('y = 8'),
-            VariableEntry('y', '8'),
-            LineEntry('return y + x'),
-            ReturnEntry('return y + x'),
-            ReturnValueEntry('15'),
-        )
+            output,
+            (
+                SourcePathEntry(),
+                VariableEntry('foo', value_regex="u?'baba'"),
+                CallEntry('def my_function(foo):'),
+                LineEntry('x = 7'),
+                VariableEntry('x', '7'),
+                LineEntry('y = 8'),
+                VariableEntry('y', '8'),
+                LineEntry('return y + x'),
+                ReturnEntry('return y + x'),
+                ReturnValueEntry('15'),
+            )
     )
 
 
 def test_thread_info():
-
     @pysnooper.snoop(thread_info=True)
     def my_function(foo):
         x = 7
@@ -62,24 +61,23 @@ def test_thread_info():
     assert result == 15
     output = output_capturer.string_io.getvalue()
     assert_output(
-        output,
-        (
-            SourcePathEntry(),
-            VariableEntry('foo', value_regex="u?'baba'"),
-            CallEntry('def my_function(foo):'),
-            LineEntry('x = 7'),
-            VariableEntry('x', '7'),
-            LineEntry('y = 8'),
-            VariableEntry('y', '8'),
-            LineEntry('return y + x'),
-            ReturnEntry('return y + x'),
-            ReturnValueEntry('15'),
-        )
+            output,
+            (
+                SourcePathEntry(),
+                VariableEntry('foo', value_regex="u?'baba'"),
+                CallEntry('def my_function(foo):'),
+                LineEntry('x = 7'),
+                VariableEntry('x', '7'),
+                LineEntry('y = 8'),
+                VariableEntry('y', '8'),
+                LineEntry('return y + x'),
+                ReturnEntry('return y + x'),
+                ReturnValueEntry('15'),
+            )
     )
 
 
 def test_multi_thread_info():
-
     @pysnooper.snoop(thread_info=True)
     def my_function(foo):
         x = 7
@@ -92,10 +90,10 @@ def test_multi_thread_info():
     with mini_toolbox.OutputCapturer(stdout=False,
                                      stderr=True) as output_capturer:
         my_function('baba')
-        t1 = threading.Thread(target=my_function, name="test123",args=['bubu'])
+        t1 = threading.Thread(target=my_function, name="test123", args=['bubu'])
         t1.start()
         t1.join()
-        t1 = threading.Thread(target=my_function, name="bibi",args=['bibi'])
+        t1 = threading.Thread(target=my_function, name="bibi", args=['bibi'])
         t1.start()
         t1.join()
     output = output_capturer.string_io.getvalue()
@@ -105,57 +103,57 @@ def test_multi_thread_info():
     assert parse_call_content(main_thread) == parse_call_content(calls[2])
     thread_info_regex = '([0-9]+-{name}+[ ]+)'
     assert_output(
-        output,
-        (
-            SourcePathEntry(),
-            VariableEntry('foo', value_regex="u?'baba'"),
-            CallEntry('def my_function(foo):',
-                      thread_info_regex=thread_info_regex.format(
-                          name="MainThread")),
-            LineEntry('x = 7',
-                      thread_info_regex=thread_info_regex.format(
-                          name="MainThread")),
-            VariableEntry('x', '7'),
-            LineEntry('y = 8',
-                      thread_info_regex=thread_info_regex.format(
-                          name="MainThread")),
-            VariableEntry('y', '8'),
-            LineEntry('return y + x',
-                      thread_info_regex=thread_info_regex.format(
-                          name="MainThread")),
-            ReturnEntry('return y + x'),
-            ReturnValueEntry('15'),
-            VariableEntry('foo', value_regex="u?'bubu'"),
-            CallEntry('def my_function(foo):',
-                      thread_info_regex=thread_info_regex.format(
-                          name="test123")),
-            LineEntry('x = 7',
-                      thread_info_regex=thread_info_regex.format(
-                          name="test123")),
-            VariableEntry('x', '7'),
-            LineEntry('y = 8',
-                      thread_info_regex=thread_info_regex.format(
-                          name="test123")),
-            VariableEntry('y', '8'),
-            LineEntry('return y + x',
-                      thread_info_regex=thread_info_regex.format(
-                          name="test123")),
-            ReturnEntry('return y + x'),
-            ReturnValueEntry('15'),
-            VariableEntry('foo', value_regex="u?'bibi'"),
-            CallEntry('def my_function(foo):',
-                      thread_info_regex=thread_info_regex.format(name='bibi')),
-            LineEntry('x = 7',
-                      thread_info_regex=thread_info_regex.format(name='bibi')),
-            VariableEntry('x', '7'),
-            LineEntry('y = 8',
-                      thread_info_regex=thread_info_regex.format(name='bibi')),
-            VariableEntry('y', '8'),
-            LineEntry('return y + x',
-                      thread_info_regex=thread_info_regex.format(name='bibi')),
-            ReturnEntry('return y + x'),
-            ReturnValueEntry('15'),
-        )
+            output,
+            (
+                SourcePathEntry(),
+                VariableEntry('foo', value_regex="u?'baba'"),
+                CallEntry('def my_function(foo):',
+                          thread_info_regex=thread_info_regex.format(
+                                  name="MainThread")),
+                LineEntry('x = 7',
+                          thread_info_regex=thread_info_regex.format(
+                                  name="MainThread")),
+                VariableEntry('x', '7'),
+                LineEntry('y = 8',
+                          thread_info_regex=thread_info_regex.format(
+                                  name="MainThread")),
+                VariableEntry('y', '8'),
+                LineEntry('return y + x',
+                          thread_info_regex=thread_info_regex.format(
+                                  name="MainThread")),
+                ReturnEntry('return y + x'),
+                ReturnValueEntry('15'),
+                VariableEntry('foo', value_regex="u?'bubu'"),
+                CallEntry('def my_function(foo):',
+                          thread_info_regex=thread_info_regex.format(
+                                  name="test123")),
+                LineEntry('x = 7',
+                          thread_info_regex=thread_info_regex.format(
+                                  name="test123")),
+                VariableEntry('x', '7'),
+                LineEntry('y = 8',
+                          thread_info_regex=thread_info_regex.format(
+                                  name="test123")),
+                VariableEntry('y', '8'),
+                LineEntry('return y + x',
+                          thread_info_regex=thread_info_regex.format(
+                                  name="test123")),
+                ReturnEntry('return y + x'),
+                ReturnValueEntry('15'),
+                VariableEntry('foo', value_regex="u?'bibi'"),
+                CallEntry('def my_function(foo):',
+                          thread_info_regex=thread_info_regex.format(name='bibi')),
+                LineEntry('x = 7',
+                          thread_info_regex=thread_info_regex.format(name='bibi')),
+                VariableEntry('x', '7'),
+                LineEntry('y = 8',
+                          thread_info_regex=thread_info_regex.format(name='bibi')),
+                VariableEntry('y', '8'),
+                LineEntry('return y + x',
+                          thread_info_regex=thread_info_regex.format(name='bibi')),
+                ReturnEntry('return y + x'),
+                ReturnValueEntry('15'),
+            )
     )
 
 
@@ -175,25 +173,23 @@ def test_callable():
     assert result == 15
     output = string_io.getvalue()
     assert_output(
-        output,
-        (
-            SourcePathEntry(),
-            VariableEntry('foo', value_regex="u?'baba'"),
-            CallEntry('def my_function(foo):'),
-            LineEntry('x = 7'),
-            VariableEntry('x', '7'),
-            LineEntry('y = 8'),
-            VariableEntry('y', '8'),
-            LineEntry('return y + x'),
-            ReturnEntry('return y + x'),
-            ReturnValueEntry('15'),
-        )
+            output,
+            (
+                SourcePathEntry(),
+                VariableEntry('foo', value_regex="u?'baba'"),
+                CallEntry('def my_function(foo):'),
+                LineEntry('x = 7'),
+                VariableEntry('x', '7'),
+                LineEntry('y = 8'),
+                VariableEntry('y', '8'),
+                LineEntry('return y + x'),
+                ReturnEntry('return y + x'),
+                ReturnValueEntry('15'),
+            )
     )
 
 
-
 def test_watch():
-
     class Foo(object):
         def __init__(self):
             self.x = 2
@@ -217,30 +213,30 @@ def test_watch():
     assert result is None
     output = output_capturer.string_io.getvalue()
     assert_output(
-        output,
-        (
-            SourcePathEntry(),
-            VariableEntry('Foo'),
-            VariableEntry('io.__name__', "'io'"),
-            CallEntry('def my_function():'),
-            LineEntry('foo = Foo()'),
-            VariableEntry('foo'),
-            VariableEntry('foo.x', '2'),
-            VariableEntry('len(foo.__dict__["x"] * "abc")', '6'),
-            LineEntry(),
-            VariableEntry('i', '0'),
-            LineEntry(),
-            VariableEntry('foo.x', '4'),
-            VariableEntry('len(foo.__dict__["x"] * "abc")', '12'),
-            LineEntry(),
-            VariableEntry('i', '1'),
-            LineEntry(),
-            VariableEntry('foo.x', '16'),
-            VariableEntry('len(foo.__dict__["x"] * "abc")', '48'),
-            LineEntry(),
-            ReturnEntry(),
-            ReturnValueEntry('None')
-        )
+            output,
+            (
+                SourcePathEntry(),
+                VariableEntry('Foo'),
+                VariableEntry('io.__name__', "'io'"),
+                CallEntry('def my_function():'),
+                LineEntry('foo = Foo()'),
+                VariableEntry('foo'),
+                VariableEntry('foo.x', '2'),
+                VariableEntry('len(foo.__dict__["x"] * "abc")', '6'),
+                LineEntry(),
+                VariableEntry('i', '0'),
+                LineEntry(),
+                VariableEntry('foo.x', '4'),
+                VariableEntry('len(foo.__dict__["x"] * "abc")', '12'),
+                LineEntry(),
+                VariableEntry('i', '1'),
+                LineEntry(),
+                VariableEntry('foo.x', '16'),
+                VariableEntry('len(foo.__dict__["x"] * "abc")', '48'),
+                LineEntry(),
+                ReturnEntry(),
+                ReturnValueEntry('None')
+            )
     )
 
 
@@ -249,7 +245,6 @@ def test_watch_explode():
         def __init__(self, x, y):
             self.x = x
             self.y = y
-
 
     @pysnooper.snoop(watch_explode=('_d', '_point', 'lst + []'))
     def my_function():
@@ -264,33 +259,33 @@ def test_watch_explode():
     assert result is None
     output = output_capturer.string_io.getvalue()
     assert_output(
-        output,
-        (
-            SourcePathEntry(),
-            VariableEntry('Foo'),
-            CallEntry('def my_function():'),
-            LineEntry(),
-            VariableEntry('_d'),
-            VariableEntry("_d['a']", '1'),
-            VariableEntry("_d['b']", '2'),
-            VariableEntry("_d['c']", "'ignore'"),
-            LineEntry(),
-            VariableEntry('_point'),
-            VariableEntry('_point.x', '3'),
-            VariableEntry('_point.y', '4'),
-            LineEntry(),
-            VariableEntry('lst'),
-            VariableEntry('(lst + [])[0]', '7'),
-            VariableEntry('(lst + [])[1]', '8'),
-            VariableEntry('(lst + [])[2]', '9'),
-            VariableEntry('lst + []'),
-            LineEntry(),
-            VariableEntry('lst'),
-            VariableEntry('(lst + [])[3]', '10'),
-            VariableEntry('lst + []'),
-            ReturnEntry(),
-            ReturnValueEntry('None')
-        )
+            output,
+            (
+                SourcePathEntry(),
+                VariableEntry('Foo'),
+                CallEntry('def my_function():'),
+                LineEntry(),
+                VariableEntry('_d'),
+                VariableEntry("_d['a']", '1'),
+                VariableEntry("_d['b']", '2'),
+                VariableEntry("_d['c']", "'ignore'"),
+                LineEntry(),
+                VariableEntry('_point'),
+                VariableEntry('_point.x', '3'),
+                VariableEntry('_point.y', '4'),
+                LineEntry(),
+                VariableEntry('lst'),
+                VariableEntry('(lst + [])[0]', '7'),
+                VariableEntry('(lst + [])[1]', '8'),
+                VariableEntry('(lst + [])[2]', '9'),
+                VariableEntry('lst + []'),
+                LineEntry(),
+                VariableEntry('lst'),
+                VariableEntry('(lst + [])[3]', '10'),
+                VariableEntry('lst + []'),
+                ReturnEntry(),
+                ReturnValueEntry('None')
+            )
     )
 
 
@@ -319,33 +314,31 @@ def test_variables_classes():
     assert result is None
     output = output_capturer.string_io.getvalue()
     assert_output(
-        output,
-        (
-            SourcePathEntry(),
-            VariableEntry('WithSlots'),
-            CallEntry('def my_function():'),
-            LineEntry(),
-            VariableEntry('_d'),
-            VariableEntry("_d['a']", '1'),
-            VariableEntry("_d['b']", '2'),
-            LineEntry(),
-            VariableEntry('_s'),
-            VariableEntry('_s.x', '3'),
-            VariableEntry('_s.y', '4'),
-            LineEntry(),
-            VariableEntry('_lst'),
-            VariableEntry('_lst[997]', '997'),
-            VariableEntry('_lst[998]', '998'),
-            VariableEntry('_lst[999]', '999'),
-            ReturnEntry(),
-            ReturnValueEntry('None')
-        )
+            output,
+            (
+                SourcePathEntry(),
+                VariableEntry('WithSlots'),
+                CallEntry('def my_function():'),
+                LineEntry(),
+                VariableEntry('_d'),
+                VariableEntry("_d['a']", '1'),
+                VariableEntry("_d['b']", '2'),
+                LineEntry(),
+                VariableEntry('_s'),
+                VariableEntry('_s.x', '3'),
+                VariableEntry('_s.y', '4'),
+                LineEntry(),
+                VariableEntry('_lst'),
+                VariableEntry('_lst[997]', '997'),
+                VariableEntry('_lst[998]', '998'),
+                VariableEntry('_lst[999]', '999'),
+                ReturnEntry(),
+                ReturnValueEntry('None')
+            )
     )
 
 
-
 def test_single_watch_no_comma():
-
     class Foo(object):
         def __init__(self):
             self.x = 2
@@ -365,23 +358,23 @@ def test_single_watch_no_comma():
     assert result is None
     output = output_capturer.string_io.getvalue()
     assert_output(
-        output,
-        (
-            SourcePathEntry(),
-            VariableEntry('Foo'),
-            CallEntry('def my_function():'),
-            LineEntry('foo = Foo()'),
-            VariableEntry('foo'),
-            LineEntry(),
-            VariableEntry('i', '0'),
-            LineEntry(),
-            LineEntry(),
-            VariableEntry('i', '1'),
-            LineEntry(),
-            LineEntry(),
-            ReturnEntry(),
-            ReturnValueEntry('None')
-        )
+            output,
+            (
+                SourcePathEntry(),
+                VariableEntry('Foo'),
+                CallEntry('def my_function():'),
+                LineEntry('foo = Foo()'),
+                VariableEntry('foo'),
+                LineEntry(),
+                VariableEntry('i', '0'),
+                LineEntry(),
+                LineEntry(),
+                VariableEntry('i', '1'),
+                LineEntry(),
+                LineEntry(),
+                ReturnEntry(),
+                ReturnValueEntry('None')
+            )
     )
 
 
@@ -398,18 +391,17 @@ def test_long_variable():
     output = output_capturer.string_io.getvalue()
     regex = r'^(?=.{100}$)\[0, 1, 2, .*\.\.\..*, 997, 998, 999\]$'
     assert_output(
-        output,
-        (
-            SourcePathEntry(),
-            CallEntry('def my_function():'),
-            LineEntry('foo = list(range(1000))'),
-            VariableEntry('foo', value_regex=regex),
-            LineEntry(),
-            ReturnEntry(),
-            ReturnValueEntry(value_regex=regex)
-        )
+            output,
+            (
+                SourcePathEntry(),
+                CallEntry('def my_function():'),
+                LineEntry('foo = list(range(1000))'),
+                VariableEntry('foo', value_regex=regex),
+                LineEntry(),
+                ReturnEntry(),
+                ReturnValueEntry(value_regex=regex)
+            )
     )
-
 
 
 def test_long_variable_with_custom_max_variable_length():
@@ -425,16 +417,16 @@ def test_long_variable_with_custom_max_variable_length():
     output = output_capturer.string_io.getvalue()
     regex = r'^(?=.{200}$)\[0, 1, 2, .*\.\.\..*, 997, 998, 999\]$'
     assert_output(
-        output,
-        (
-            SourcePathEntry(),
-            CallEntry('def my_function():'),
-            LineEntry('foo = list(range(1000))'),
-            VariableEntry('foo', value_regex=regex),
-            LineEntry(),
-            ReturnEntry(),
-            ReturnValueEntry(value_regex=regex)
-        )
+            output,
+            (
+                SourcePathEntry(),
+                CallEntry('def my_function():'),
+                LineEntry('foo = list(range(1000))'),
+                VariableEntry('foo', value_regex=regex),
+                LineEntry(),
+                ReturnEntry(),
+                ReturnValueEntry(value_regex=regex)
+            )
     )
 
 
@@ -451,18 +443,17 @@ def test_long_variable_with_infinite_max_variable_length():
     output = output_capturer.string_io.getvalue()
     regex = r'^(?=.{1000,100000}$)\[0, 1, 2, [^.]+ 997, 998, 999\]$'
     assert_output(
-        output,
-        (
-            SourcePathEntry(),
-            CallEntry('def my_function():'),
-            LineEntry('foo = list(range(1000))'),
-            VariableEntry('foo', value_regex=regex),
-            LineEntry(),
-            ReturnEntry(),
-            ReturnValueEntry(value_regex=regex)
-        )
+            output,
+            (
+                SourcePathEntry(),
+                CallEntry('def my_function():'),
+                LineEntry('foo = list(range(1000))'),
+                VariableEntry('foo', value_regex=regex),
+                LineEntry(),
+                ReturnEntry(),
+                ReturnValueEntry(value_regex=regex)
+            )
     )
-
 
 
 def test_repr_exception():
@@ -480,16 +471,16 @@ def test_repr_exception():
     assert result is None
     output = output_capturer.string_io.getvalue()
     assert_output(
-        output,
-        (
-            SourcePathEntry(),
-            VariableEntry('Bad'),
-            CallEntry('def my_function():'),
-            LineEntry('bad = Bad()'),
-            VariableEntry('bad', value='REPR FAILED'),
-            ReturnEntry(),
-            ReturnValueEntry('None')
-        )
+            output,
+            (
+                SourcePathEntry(),
+                VariableEntry('Bad'),
+                CallEntry('def my_function():'),
+                LineEntry('bad = Bad()'),
+                VariableEntry('bad', value='REPR FAILED'),
+                ReturnEntry(),
+                ReturnValueEntry('None')
+            )
     )
 
 
@@ -517,39 +508,39 @@ def test_depth():
     assert result == 20
     output = string_io.getvalue()
     assert_output(
-        output,
-        (
-            SourcePathEntry(),
-            VariableEntry(),
-            VariableEntry(),
-            CallEntry('def f1(x1):'),
-            LineEntry(),
+            output,
+            (
+                SourcePathEntry(),
+                VariableEntry(),
+                VariableEntry(),
+                CallEntry('def f1(x1):'),
+                LineEntry(),
 
-            VariableEntry(),
-            VariableEntry(),
-            CallEntry('def f2(x2):'),
-            LineEntry(),
+                VariableEntry(),
+                VariableEntry(),
+                CallEntry('def f2(x2):'),
+                LineEntry(),
 
-            VariableEntry(),
-            VariableEntry(),
-            CallEntry('def f3(x3):'),
-            LineEntry(),
+                VariableEntry(),
+                VariableEntry(),
+                CallEntry('def f3(x3):'),
+                LineEntry(),
 
-            VariableEntry(),
-            LineEntry(),
-            ReturnEntry(),
-            ReturnValueEntry('20'),
+                VariableEntry(),
+                LineEntry(),
+                ReturnEntry(),
+                ReturnValueEntry('20'),
 
-            VariableEntry(),
-            LineEntry(),
-            ReturnEntry(),
-            ReturnValueEntry('20'),
+                VariableEntry(),
+                LineEntry(),
+                ReturnEntry(),
+                ReturnValueEntry('20'),
 
-            VariableEntry(),
-            LineEntry(),
-            ReturnEntry(),
-            ReturnValueEntry('20'),
-        )
+                VariableEntry(),
+                LineEntry(),
+                ReturnEntry(),
+                ReturnValueEntry('20'),
+            )
     )
 
 
@@ -573,21 +564,21 @@ def test_method_and_prefix():
     assert result.x == 4
     output = output_capturer.string_io.getvalue()
     assert_output(
-        output,
-        (
-            SourcePathEntry(prefix='ZZZ'),
-            VariableEntry('self', prefix='ZZZ'),
-            VariableEntry('self.x', '2', prefix='ZZZ'),
-            CallEntry('def square(self):', prefix='ZZZ'),
-            LineEntry('foo = 7', prefix='ZZZ'),
-            VariableEntry('foo', '7', prefix='ZZZ'),
-            LineEntry('self.x **= 2', prefix='ZZZ'),
-            VariableEntry('self.x', '4', prefix='ZZZ'),
-            LineEntry(prefix='ZZZ'),
-            ReturnEntry(prefix='ZZZ'),
-            ReturnValueEntry(prefix='ZZZ'),
-        ),
-        prefix='ZZZ'
+            output,
+            (
+                SourcePathEntry(prefix='ZZZ'),
+                VariableEntry('self', prefix='ZZZ'),
+                VariableEntry('self.x', '2', prefix='ZZZ'),
+                CallEntry('def square(self):', prefix='ZZZ'),
+                LineEntry('foo = 7', prefix='ZZZ'),
+                VariableEntry('foo', '7', prefix='ZZZ'),
+                LineEntry('self.x **= 2', prefix='ZZZ'),
+                VariableEntry('self.x', '4', prefix='ZZZ'),
+                LineEntry(prefix='ZZZ'),
+                ReturnEntry(prefix='ZZZ'),
+                ReturnValueEntry(prefix='ZZZ'),
+            ),
+            prefix='ZZZ'
     )
 
 
@@ -606,19 +597,19 @@ def test_file_output():
         with path.open() as output_file:
             output = output_file.read()
         assert_output(
-            output,
-            (
-                SourcePathEntry(),
-                VariableEntry('_foo', value_regex="u?'baba'"),
-                CallEntry('def my_function(_foo):'),
-                LineEntry('x = 7'),
-                VariableEntry('x', '7'),
-                LineEntry('y = 8'),
-                VariableEntry('y', '8'),
-                LineEntry('return y + x'),
-                ReturnEntry('return y + x'),
-                ReturnValueEntry('15'),
-            )
+                output,
+                (
+                    SourcePathEntry(),
+                    VariableEntry('_foo', value_regex="u?'baba'"),
+                    CallEntry('def my_function(_foo):'),
+                    LineEntry('x = 7'),
+                    VariableEntry('x', '7'),
+                    LineEntry('y = 8'),
+                    VariableEntry('y', '8'),
+                    LineEntry('return y + x'),
+                    ReturnEntry('return y + x'),
+                    ReturnValueEntry('15'),
+                )
         )
 
 
@@ -642,26 +633,26 @@ def test_confusing_decorator_lines():
     assert result == 15
     output = string_io.getvalue()
     assert_output(
-        output,
-        (
-            SourcePathEntry(),
-            VariableEntry('foo', value_regex="u?'baba'"),
-            CallEntry('def my_function(foo):'),
-            LineEntry(),
-            VariableEntry(),
-            LineEntry(),
-            VariableEntry(),
-            LineEntry(),
-            # inside lambda
-            VariableEntry('bar', value_regex="u?'baba'"),
-            CallEntry('x = lambda bar: 7'),
-            LineEntry(),
-            ReturnEntry(),
-            ReturnValueEntry('7'),
-            # back in my_function
-            ReturnEntry(),
-            ReturnValueEntry('15'),
-        )
+            output,
+            (
+                SourcePathEntry(),
+                VariableEntry('foo', value_regex="u?'baba'"),
+                CallEntry('def my_function(foo):'),
+                LineEntry(),
+                VariableEntry(),
+                LineEntry(),
+                VariableEntry(),
+                LineEntry(),
+                # inside lambda
+                VariableEntry('bar', value_regex="u?'baba'"),
+                CallEntry('x = lambda bar: 7'),
+                LineEntry(),
+                ReturnEntry(),
+                ReturnValueEntry('7'),
+                # back in my_function
+                ReturnEntry(),
+                ReturnValueEntry('15'),
+            )
     )
 
 
@@ -672,21 +663,21 @@ def test_lambda():
     assert result == 49
     output = string_io.getvalue()
     assert_output(
-        output,
-        (
-            SourcePathEntry(),
-            VariableEntry('x', '7'),
-            CallEntry(source_regex='^my_function = pysnooper.*'),
-            LineEntry(source_regex='^my_function = pysnooper.*'),
-            ReturnEntry(source_regex='^my_function = pysnooper.*'),
-            ReturnValueEntry('49'),
-        )
+            output,
+            (
+                SourcePathEntry(),
+                VariableEntry('x', '7'),
+                CallEntry(source_regex='^my_function = pysnooper.*'),
+                LineEntry(source_regex='^my_function = pysnooper.*'),
+                ReturnEntry(source_regex='^my_function = pysnooper.*'),
+                ReturnValueEntry('49'),
+            )
     )
 
 
 def test_unavailable_source():
     with mini_toolbox.create_temp_folder(prefix='pysnooper') as folder, \
-                                    mini_toolbox.TempSysPathAdder(str(folder)):
+            mini_toolbox.TempSysPathAdder(str(folder)):
         module_name = 'iaerojajsijf'
         python_file_path = folder / ('%s.py' % (module_name,))
         content = textwrap.dedent(u'''
@@ -705,15 +696,15 @@ def test_unavailable_source():
         assert result == 7
         output = output_capturer.output
         assert_output(
-            output,
-            (
-                SourcePathEntry(),
-                VariableEntry(stage='starting'),
-                CallEntry('SOURCE IS UNAVAILABLE'),
-                LineEntry('SOURCE IS UNAVAILABLE'),
-                ReturnEntry('SOURCE IS UNAVAILABLE'),
-                ReturnValueEntry('7'),
-            )
+                output,
+                (
+                    SourcePathEntry(),
+                    VariableEntry(stage='starting'),
+                    CallEntry('SOURCE IS UNAVAILABLE'),
+                    LineEntry('SOURCE IS UNAVAILABLE'),
+                    ReturnEntry('SOURCE IS UNAVAILABLE'),
+                    ReturnValueEntry('7'),
+                )
         )
 
 
@@ -722,11 +713,13 @@ def test_no_overwrite_by_default():
         path = folder / 'foo.log'
         with path.open('w') as output_file:
             output_file.write(u'lala')
+
         @pysnooper.snoop(str(path))
         def my_function(foo):
             x = 7
             y = 8
             return y + x
+
         result = my_function('baba')
         assert result == 15
         with path.open() as output_file:
@@ -734,19 +727,19 @@ def test_no_overwrite_by_default():
         assert output.startswith('lala')
         shortened_output = output[4:]
         assert_output(
-            shortened_output,
-            (
-                SourcePathEntry(),
-                VariableEntry('foo', value_regex="u?'baba'"),
-                CallEntry('def my_function(foo):'),
-                LineEntry('x = 7'),
-                VariableEntry('x', '7'),
-                LineEntry('y = 8'),
-                VariableEntry('y', '8'),
-                LineEntry('return y + x'),
-                ReturnEntry('return y + x'),
-                ReturnValueEntry('15'),
-            )
+                shortened_output,
+                (
+                    SourcePathEntry(),
+                    VariableEntry('foo', value_regex="u?'baba'"),
+                    CallEntry('def my_function(foo):'),
+                    LineEntry('x = 7'),
+                    VariableEntry('x', '7'),
+                    LineEntry('y = 8'),
+                    VariableEntry('y', '8'),
+                    LineEntry('return y + x'),
+                    ReturnEntry('return y + x'),
+                    ReturnValueEntry('15'),
+                )
         )
 
 
@@ -755,11 +748,13 @@ def test_overwrite():
         path = folder / 'foo.log'
         with path.open('w') as output_file:
             output_file.write(u'lala')
+
         @pysnooper.snoop(str(path), overwrite=True)
         def my_function(foo):
             x = 7
             y = 8
             return y + x
+
         result = my_function('baba')
         result = my_function('baba')
         assert result == 15
@@ -767,29 +762,29 @@ def test_overwrite():
             output = output_file.read()
         assert 'lala' not in output
         assert_output(
-            output,
-            (
-                SourcePathEntry(),
-                VariableEntry('foo', value_regex="u?'baba'"),
-                CallEntry('def my_function(foo):'),
-                LineEntry('x = 7'),
-                VariableEntry('x', '7'),
-                LineEntry('y = 8'),
-                VariableEntry('y', '8'),
-                LineEntry('return y + x'),
-                ReturnEntry('return y + x'),
-                ReturnValueEntry('15'),
+                output,
+                (
+                    SourcePathEntry(),
+                    VariableEntry('foo', value_regex="u?'baba'"),
+                    CallEntry('def my_function(foo):'),
+                    LineEntry('x = 7'),
+                    VariableEntry('x', '7'),
+                    LineEntry('y = 8'),
+                    VariableEntry('y', '8'),
+                    LineEntry('return y + x'),
+                    ReturnEntry('return y + x'),
+                    ReturnValueEntry('15'),
 
-                VariableEntry('foo', value_regex="u?'baba'"),
-                CallEntry('def my_function(foo):'),
-                LineEntry('x = 7'),
-                VariableEntry('x', '7'),
-                LineEntry('y = 8'),
-                VariableEntry('y', '8'),
-                LineEntry('return y + x'),
-                ReturnEntry('return y + x'),
-                ReturnValueEntry('15'),
-            )
+                    VariableEntry('foo', value_regex="u?'baba'"),
+                    CallEntry('def my_function(foo):'),
+                    LineEntry('x = 7'),
+                    VariableEntry('x', '7'),
+                    LineEntry('y = 8'),
+                    VariableEntry('y', '8'),
+                    LineEntry('return y + x'),
+                    ReturnEntry('return y + x'),
+                    ReturnValueEntry('15'),
+                )
         )
 
 
@@ -862,84 +857,84 @@ def test_with_block():
     assert result == 2
     output = output_capturer.string_io.getvalue()
     assert_output(
-        output,
-        (
-            # In first with
-            SourcePathEntry(),
-            VariableEntry('x', '2'),
-            VariableEntry('bar1'),
-            VariableEntry('bar2'),
-            VariableEntry('bar3'),
-            VariableEntry('foo'),
-            VariableEntry('qux'),
-            VariableEntry('snoop'),
-            LineEntry('foo(x - 1)'),
+            output,
+            (
+                # In first with
+                SourcePathEntry(),
+                VariableEntry('x', '2'),
+                VariableEntry('bar1'),
+                VariableEntry('bar2'),
+                VariableEntry('bar3'),
+                VariableEntry('foo'),
+                VariableEntry('qux'),
+                VariableEntry('snoop'),
+                LineEntry('foo(x - 1)'),
 
-            # In with in recursive call
-            VariableEntry('x', '1'),
-            VariableEntry('bar1'),
-            VariableEntry('bar2'),
-            VariableEntry('bar3'),
-            VariableEntry('foo'),
-            VariableEntry('qux'),
-            VariableEntry('snoop'),
-            LineEntry('foo(x - 1)'),
+                # In with in recursive call
+                VariableEntry('x', '1'),
+                VariableEntry('bar1'),
+                VariableEntry('bar2'),
+                VariableEntry('bar3'),
+                VariableEntry('foo'),
+                VariableEntry('qux'),
+                VariableEntry('snoop'),
+                LineEntry('foo(x - 1)'),
 
-            # Call to bar1 from if block outside with
-            VariableEntry('_x', '0'),
-            VariableEntry('qux'),
-            CallEntry('def bar1(_x):'),
-            LineEntry('qux()'),
-            ReturnEntry('qux()'),
-            ReturnValueEntry('None'),
+                # Call to bar1 from if block outside with
+                VariableEntry('_x', '0'),
+                VariableEntry('qux'),
+                CallEntry('def bar1(_x):'),
+                LineEntry('qux()'),
+                ReturnEntry('qux()'),
+                ReturnValueEntry('None'),
 
-            # In with in recursive call
-            LineEntry('bar2(x)'),
+                # In with in recursive call
+                LineEntry('bar2(x)'),
 
-            # Call to bar2 from within with
-            VariableEntry('_x', '1'),
-            VariableEntry('qux'),
-            CallEntry('def bar2(_x):'),
-            LineEntry('qux()'),
-            ReturnEntry('qux()'),
-            ReturnValueEntry('None'),
+                # Call to bar2 from within with
+                VariableEntry('_x', '1'),
+                VariableEntry('qux'),
+                CallEntry('def bar2(_x):'),
+                LineEntry('qux()'),
+                ReturnEntry('qux()'),
+                ReturnValueEntry('None'),
 
-            # In with in recursive call
-            LineEntry('qux()'),
+                # In with in recursive call
+                LineEntry('qux()'),
 
-            # Call to bar3 from after with
-            VariableEntry('_x', '9'),
-            VariableEntry('qux'),
-            CallEntry('def bar3(_x):'),
-            LineEntry('qux()'),
-            ReturnEntry('qux()'),
-            ReturnValueEntry('None'),
+                # Call to bar3 from after with
+                VariableEntry('_x', '9'),
+                VariableEntry('qux'),
+                CallEntry('def bar3(_x):'),
+                LineEntry('qux()'),
+                ReturnEntry('qux()'),
+                ReturnValueEntry('None'),
 
-            # -- Similar to previous few sections,
-            # -- but from first call to foo
+                # -- Similar to previous few sections,
+                # -- but from first call to foo
 
-            # In with in first call
-            LineEntry('bar2(x)'),
+                # In with in first call
+                LineEntry('bar2(x)'),
 
-            # Call to bar2 from within with
-            VariableEntry('_x', '2'),
-            VariableEntry('qux'),
-            CallEntry('def bar2(_x):'),
-            LineEntry('qux()'),
-            ReturnEntry('qux()'),
-            ReturnValueEntry('None'),
+                # Call to bar2 from within with
+                VariableEntry('_x', '2'),
+                VariableEntry('qux'),
+                CallEntry('def bar2(_x):'),
+                LineEntry('qux()'),
+                ReturnEntry('qux()'),
+                ReturnValueEntry('None'),
 
-            # In with in first call
-            LineEntry('qux()'),
+                # In with in first call
+                LineEntry('qux()'),
 
-            # Call to bar3 from after with
-            VariableEntry('_x', '9'),
-            VariableEntry('qux'),
-            CallEntry('def bar3(_x):'),
-            LineEntry('qux()'),
-            ReturnEntry('qux()'),
-            ReturnValueEntry('None'),
-        ),
+                # Call to bar3 from after with
+                VariableEntry('_x', '9'),
+                VariableEntry('qux'),
+                CallEntry('def bar3(_x):'),
+                LineEntry('qux()'),
+                ReturnEntry('qux()'),
+                ReturnValueEntry('None'),
+            ),
     )
 
 
@@ -968,35 +963,36 @@ def test_with_block_depth():
     assert result == 20
     output = string_io.getvalue()
     assert_output(
-        output,
-        (
-            SourcePathEntry(),
-            VariableEntry(),
-            VariableEntry(),
-            VariableEntry(),
-            LineEntry('result1 = f2(x1)'),
+            output,
+            (
+                SourcePathEntry(),
+                VariableEntry(),
+                VariableEntry(),
+                VariableEntry(),
+                LineEntry('result1 = f2(x1)'),
 
-            VariableEntry(),
-            VariableEntry(),
-            CallEntry('def f2(x2):'),
-            LineEntry(),
+                VariableEntry(),
+                VariableEntry(),
+                CallEntry('def f2(x2):'),
+                LineEntry(),
 
-            VariableEntry(),
-            VariableEntry(),
-            CallEntry('def f3(x3):'),
-            LineEntry(),
+                VariableEntry(),
+                VariableEntry(),
+                CallEntry('def f3(x3):'),
+                LineEntry(),
 
-            VariableEntry(),
-            LineEntry(),
-            ReturnEntry(),
-            ReturnValueEntry('20'),
+                VariableEntry(),
+                LineEntry(),
+                ReturnEntry(),
+                ReturnValueEntry('20'),
 
-            VariableEntry(),
-            LineEntry(),
-            ReturnEntry(),
-            ReturnValueEntry('20'),
-        )
+                VariableEntry(),
+                LineEntry(),
+                ReturnEntry(),
+                ReturnValueEntry('20'),
+            )
     )
+
 
 def test_cellvars():
     string_io = io.StringIO()
@@ -1005,10 +1001,13 @@ def test_cellvars():
         def f3(a):
             x = 0
             x += 1
+
             def f4(a):
                 y = x
                 return 42
+
             return f4(a)
+
         return f3(a)
 
     def f1(a):
@@ -1020,45 +1019,46 @@ def test_cellvars():
     assert result == 42
     output = string_io.getvalue()
     assert_output(
-        output,
-        (
-            SourcePathEntry(),
-            VariableEntry(),
-            VariableEntry(),
-            VariableEntry(),
-            LineEntry('result1 = f2(a)'),
+            output,
+            (
+                SourcePathEntry(),
+                VariableEntry(),
+                VariableEntry(),
+                VariableEntry(),
+                LineEntry('result1 = f2(a)'),
 
-            VariableEntry(),
-            CallEntry('def f2(a):'),
-            LineEntry(),
-            VariableEntry(),
-            LineEntry(),
+                VariableEntry(),
+                CallEntry('def f2(a):'),
+                LineEntry(),
+                VariableEntry(),
+                LineEntry(),
 
-            VariableEntry("a"),
-            CallEntry('def f3(a):'),
-            LineEntry(),
-            VariableEntry("x"),
-            LineEntry(),
-            VariableEntry("x"),
-            LineEntry(),
-            VariableEntry(),
+                VariableEntry("a"),
+                CallEntry('def f3(a):'),
+                LineEntry(),
+                VariableEntry("x"),
+                LineEntry(),
+                VariableEntry("x"),
+                LineEntry(),
+                VariableEntry(),
 
-            LineEntry(),
-            VariableEntry(),
-            VariableEntry("x"),
-            CallEntry('def f4(a):'),
-            LineEntry(),
-            VariableEntry(),
-            LineEntry(),
+                LineEntry(),
+                VariableEntry(),
+                VariableEntry("x"),
+                CallEntry('def f4(a):'),
+                LineEntry(),
+                VariableEntry(),
+                LineEntry(),
 
-            ReturnEntry(),
-            ReturnValueEntry(),
-            ReturnEntry(),
-            ReturnValueEntry(),
-            ReturnEntry(),
-            ReturnValueEntry(),
-        )
+                ReturnEntry(),
+                ReturnValueEntry(),
+                ReturnEntry(),
+                ReturnValueEntry(),
+                ReturnEntry(),
+                ReturnValueEntry(),
+            )
     )
+
 
 def test_var_order():
     string_io = io.StringIO()
@@ -1075,34 +1075,33 @@ def test_var_order():
 
     output = string_io.getvalue()
     assert_output(
-        output,
-        (
-            SourcePathEntry(),
-            VariableEntry(),
-            VariableEntry(),
+            output,
+            (
+                SourcePathEntry(),
+                VariableEntry(),
+                VariableEntry(),
 
-            LineEntry('result = f(1, 2, 3, 4)'),
-            VariableEntry("one", "1"),
-            VariableEntry("two", "2"),
-            VariableEntry("three", "3"),
-            VariableEntry("four", "4"),
+                LineEntry('result = f(1, 2, 3, 4)'),
+                VariableEntry("one", "1"),
+                VariableEntry("two", "2"),
+                VariableEntry("three", "3"),
+                VariableEntry("four", "4"),
 
-            CallEntry('def f(one, two, three, four):'),
-            LineEntry(),
-            VariableEntry("five"),
-            LineEntry(),
-            VariableEntry("six"),
-            LineEntry(),
-            VariableEntry("seven"),
-            LineEntry(),
-            VariableEntry("five", "5"),
-            VariableEntry("six", "6"),
-            VariableEntry("seven", "7"),
-            ReturnEntry(),
-            ReturnValueEntry(),
-        )
+                CallEntry('def f(one, two, three, four):'),
+                LineEntry(),
+                VariableEntry("five"),
+                LineEntry(),
+                VariableEntry("six"),
+                LineEntry(),
+                VariableEntry("seven"),
+                LineEntry(),
+                VariableEntry("five", "5"),
+                VariableEntry("six", "6"),
+                VariableEntry("seven", "7"),
+                ReturnEntry(),
+                ReturnValueEntry(),
+            )
     )
-
 
 
 def test_truncate():
@@ -1133,7 +1132,6 @@ def test_generator():
     original_tracer = sys.gettrace()
     original_tracer_active = lambda: (sys.gettrace() is original_tracer)
 
-
     @pysnooper.snoop(string_io)
     def f(x1):
         assert not original_tracer_active()
@@ -1144,7 +1142,6 @@ def test_generator():
         x4 = (yield 2)
         assert not original_tracer_active()
         return
-
 
     assert original_tracer_active()
     generator = f(0)
@@ -1161,51 +1158,51 @@ def test_generator():
 
     output = string_io.getvalue()
     assert_output(
-        output,
-        (
-            SourcePathEntry(),
-            VariableEntry('x1', '0'),
-            VariableEntry(),
-            CallEntry(),
-            LineEntry(),
-            VariableEntry(),
-            VariableEntry(),
-            LineEntry(),
-            ReturnEntry(),
-            ReturnValueEntry('0'),
+            output,
+            (
+                SourcePathEntry(),
+                VariableEntry('x1', '0'),
+                VariableEntry(),
+                CallEntry(),
+                LineEntry(),
+                VariableEntry(),
+                VariableEntry(),
+                LineEntry(),
+                ReturnEntry(),
+                ReturnValueEntry('0'),
 
-            # Pause and resume:
+                # Pause and resume:
 
-            VariableEntry('x1', '0'),
-            VariableEntry(),
-            VariableEntry(),
-            VariableEntry(),
-            CallEntry(),
-            VariableEntry('x2', "'blabla'"),
-            LineEntry(),
-            LineEntry(),
-            VariableEntry('x3', "'foo'"),
-            LineEntry(),
-            LineEntry(),
-            ReturnEntry(),
-            ReturnValueEntry('2'),
+                VariableEntry('x1', '0'),
+                VariableEntry(),
+                VariableEntry(),
+                VariableEntry(),
+                CallEntry(),
+                VariableEntry('x2', "'blabla'"),
+                LineEntry(),
+                LineEntry(),
+                VariableEntry('x3', "'foo'"),
+                LineEntry(),
+                LineEntry(),
+                ReturnEntry(),
+                ReturnValueEntry('2'),
 
-            # Pause and resume:
+                # Pause and resume:
 
-            VariableEntry('x1', '0'),
-            VariableEntry(),
-            VariableEntry(),
-            VariableEntry(),
-            VariableEntry(),
-            VariableEntry(),
-            CallEntry(),
-            VariableEntry('x4', "'looloo'"),
-            LineEntry(),
-            LineEntry(),
-            ReturnEntry(),
-            ReturnValueEntry(None),
+                VariableEntry('x1', '0'),
+                VariableEntry(),
+                VariableEntry(),
+                VariableEntry(),
+                VariableEntry(),
+                VariableEntry(),
+                CallEntry(),
+                VariableEntry('x4', "'looloo'"),
+                LineEntry(),
+                LineEntry(),
+                ReturnEntry(),
+                ReturnValueEntry(None),
 
-        )
+            )
     )
 
 
@@ -1225,9 +1222,9 @@ def test_custom_repr():
         return large(x) or isinstance(x, dict)
 
     @pysnooper.snoop(string_io, custom_repr=(
-        (large, print_list_size),
-        (dict, print_dict),
-        (evil_condition, lambda x: 'I am evil')))
+            (large, print_list_size),
+            (dict, print_dict),
+            (evil_condition, lambda x: 'I am evil')))
     def sum_to_x(x):
         l = list(range(x))
         a = {'1': 1, '2': 2}
@@ -1237,20 +1234,21 @@ def test_custom_repr():
 
     output = string_io.getvalue()
     assert_output(
-        output,
-        (
-            SourcePathEntry(),
-            VariableEntry('x', '10000'),
-            CallEntry(),
-            LineEntry(),
-            VariableEntry('l', 'list(size=10000)'),
-            LineEntry(),
-            VariableEntry('a', "dict(keys=['1', '2'])"),
-            LineEntry(),
-            ReturnEntry(),
-            ReturnValueEntry('49995000'),
-        )
+            output,
+            (
+                SourcePathEntry(),
+                VariableEntry('x', '10000'),
+                CallEntry(),
+                LineEntry(),
+                VariableEntry('l', 'list(size=10000)'),
+                LineEntry(),
+                VariableEntry('a', "dict(keys=['1', '2'])"),
+                LineEntry(),
+                ReturnEntry(),
+                ReturnValueEntry('49995000'),
+            )
     )
+
 
 def test_custom_repr_single():
     string_io = io.StringIO()
@@ -1264,17 +1262,17 @@ def test_custom_repr_single():
 
     output = string_io.getvalue()
     assert_output(
-        output,
-        (
-            SourcePathEntry(),
-            VariableEntry('x', '10000'),
-            CallEntry(),
-            LineEntry(),
-            VariableEntry('l', 'foofoo!'),
-            LineEntry(),
-            ReturnEntry(),
-            ReturnValueEntry('7'),
-        )
+            output,
+            (
+                SourcePathEntry(),
+                VariableEntry('x', '10000'),
+                CallEntry(),
+                LineEntry(),
+                VariableEntry('l', 'foofoo!'),
+                LineEntry(),
+                ReturnEntry(),
+                ReturnValueEntry('7'),
+            )
     )
 
 
@@ -1314,24 +1312,25 @@ def test_class():
     assert result == 15
     output = string_io.getvalue()
     assert_output(
-        output,
-        (
-            SourcePathEntry(),
-            VariableEntry('self', value_regex="u?.+MyClass object at"),
-            CallEntry('def __init__(self):'),
-            LineEntry('self.x = 7'),
-            ReturnEntry('self.x = 7'),
-            ReturnValueEntry('None'),
-            VariableEntry('self', value_regex="u?.+MyClass object at"),
-            VariableEntry('foo', value_regex="u?'baba'"),
-            CallEntry('def my_method(self, foo):'),
-            LineEntry('y = 8'),
-            VariableEntry('y', '8'),
-            LineEntry('return y + self.x'),
-            ReturnEntry('return y + self.x'),
-            ReturnValueEntry('15'),
-        )
+            output,
+            (
+                SourcePathEntry(),
+                VariableEntry('self', value_regex="u?.+MyClass object at"),
+                CallEntry('def __init__(self):'),
+                LineEntry('self.x = 7'),
+                ReturnEntry('self.x = 7'),
+                ReturnValueEntry('None'),
+                VariableEntry('self', value_regex="u?.+MyClass object at"),
+                VariableEntry('foo', value_regex="u?'baba'"),
+                CallEntry('def my_method(self, foo):'),
+                LineEntry('y = 8'),
+                VariableEntry('y', '8'),
+                LineEntry('return y + self.x'),
+                ReturnEntry('return y + self.x'),
+                ReturnValueEntry('15'),
+            )
     )
+
 
 def test_class_with_decorated_method():
     string_io = io.StringIO()
@@ -1340,6 +1339,7 @@ def test_class_with_decorated_method():
         def wrapper(*args, **kwargs):
             result = function(*args, **kwargs)
             return result
+
         return wrapper
 
     @pysnooper.snoop(string_io)
@@ -1357,24 +1357,24 @@ def test_class_with_decorated_method():
     assert result == 15
     output = string_io.getvalue()
     assert_output(
-        output,
-        (
-            SourcePathEntry(),
-            VariableEntry('self', value_regex="u?.+MyClass object at"),
-            CallEntry('def __init__(self):'),
-            LineEntry('self.x = 7'),
-            ReturnEntry('self.x = 7'),
-            ReturnValueEntry('None'),
-            VariableEntry('args', value_regex=r"\(<.+>, 'baba'\)"),
-            VariableEntry('kwargs', value_regex=r"\{\}"),
-            VariableEntry('function', value_regex="u?.+my_method at"),
-            CallEntry('def wrapper(*args, **kwargs):'),
-            LineEntry('result = function(*args, **kwargs)'),
-            VariableEntry('result', '15'),
-            LineEntry('return result'),
-            ReturnEntry('return result'),
-            ReturnValueEntry('15'),
-        )
+            output,
+            (
+                SourcePathEntry(),
+                VariableEntry('self', value_regex="u?.+MyClass object at"),
+                CallEntry('def __init__(self):'),
+                LineEntry('self.x = 7'),
+                ReturnEntry('self.x = 7'),
+                ReturnValueEntry('None'),
+                VariableEntry('args', value_regex=r"\(<.+>, 'baba'\)"),
+                VariableEntry('kwargs', value_regex=r"\{\}"),
+                VariableEntry('function', value_regex="u?.+my_method at"),
+                CallEntry('def wrapper(*args, **kwargs):'),
+                LineEntry('result = function(*args, **kwargs)'),
+                VariableEntry('result', '15'),
+                LineEntry('return result'),
+                ReturnEntry('return result'),
+                ReturnValueEntry('15'),
+            )
     )
 
 
@@ -1385,6 +1385,7 @@ def test_class_with_decorated_method_and_snoop_applied_to_method():
         def wrapper(*args, **kwargs):
             result = function(*args, **kwargs)
             return result
+
         return wrapper
 
     @pysnooper.snoop(string_io)
@@ -1403,33 +1404,33 @@ def test_class_with_decorated_method_and_snoop_applied_to_method():
     assert result == 15
     output = string_io.getvalue()
     assert_output(
-        output,
-        (
-            SourcePathEntry(),
-            VariableEntry('self', value_regex="u?.*MyClass object at"),
-            CallEntry('def __init__(self):'),
-            LineEntry('self.x = 7'),
-            ReturnEntry('self.x = 7'),
-            ReturnValueEntry('None'),
-            VariableEntry('args', value_regex=r"u?\(<.+>, 'baba'\)"),
-            VariableEntry('kwargs', value_regex=r"u?\{\}"),
-            VariableEntry('function', value_regex="u?.*my_method at"),
-            CallEntry('def wrapper(*args, **kwargs):'),
-            LineEntry('result = function(*args, **kwargs)'),
-            SourcePathEntry(),
-            VariableEntry('self', value_regex="u?.*MyClass object at"),
-            VariableEntry('foo', value_regex="u?'baba'"),
-            CallEntry('def my_method(self, foo):'),
-            LineEntry('y = 8'),
-            VariableEntry('y', '8'),
-            LineEntry('return y + self.x'),
-            ReturnEntry('return y + self.x'),
-            ReturnValueEntry('15'),
-            VariableEntry('result', '15'),
-            LineEntry('return result'),
-            ReturnEntry('return result'),
-            ReturnValueEntry('15'),
-        )
+            output,
+            (
+                SourcePathEntry(),
+                VariableEntry('self', value_regex="u?.*MyClass object at"),
+                CallEntry('def __init__(self):'),
+                LineEntry('self.x = 7'),
+                ReturnEntry('self.x = 7'),
+                ReturnValueEntry('None'),
+                VariableEntry('args', value_regex=r"u?\(<.+>, 'baba'\)"),
+                VariableEntry('kwargs', value_regex=r"u?\{\}"),
+                VariableEntry('function', value_regex="u?.*my_method at"),
+                CallEntry('def wrapper(*args, **kwargs):'),
+                LineEntry('result = function(*args, **kwargs)'),
+                SourcePathEntry(),
+                VariableEntry('self', value_regex="u?.*MyClass object at"),
+                VariableEntry('foo', value_regex="u?'baba'"),
+                CallEntry('def my_method(self, foo):'),
+                LineEntry('y = 8'),
+                VariableEntry('y', '8'),
+                LineEntry('return y + self.x'),
+                ReturnEntry('return y + self.x'),
+                ReturnValueEntry('15'),
+                VariableEntry('result', '15'),
+                LineEntry('return result'),
+                ReturnEntry('return result'),
+                ReturnValueEntry('15'),
+            )
     )
 
 
@@ -1475,36 +1476,36 @@ def test_class_with_property():
     # The property methods will not be traced, but their calls to plain_method will be.
     output = string_io.getvalue()
     assert_output(
-        output,
-        (
-            SourcePathEntry(),
-            VariableEntry('self', value_regex="u?.*MyClass object at"),
-            CallEntry('def __init__(self):'),
-            LineEntry('self._x = 0'),
-            ReturnEntry('self._x = 0'),
-            ReturnValueEntry('None'),
+            output,
+            (
+                SourcePathEntry(),
+                VariableEntry('self', value_regex="u?.*MyClass object at"),
+                CallEntry('def __init__(self):'),
+                LineEntry('self._x = 0'),
+                ReturnEntry('self._x = 0'),
+                ReturnValueEntry('None'),
 
-            # Called from getter
-            VariableEntry('self', value_regex="u?.*MyClass object at"),
-            CallEntry('def plain_method(self):'),
-            LineEntry('pass'),
-            ReturnEntry('pass'),
-            ReturnValueEntry('None'),
+                # Called from getter
+                VariableEntry('self', value_regex="u?.*MyClass object at"),
+                CallEntry('def plain_method(self):'),
+                LineEntry('pass'),
+                ReturnEntry('pass'),
+                ReturnValueEntry('None'),
 
-            # Called from setter
-            VariableEntry('self', value_regex="u?.*MyClass object at"),
-            CallEntry('def plain_method(self):'),
-            LineEntry('pass'),
-            ReturnEntry('pass'),
-            ReturnValueEntry('None'),
+                # Called from setter
+                VariableEntry('self', value_regex="u?.*MyClass object at"),
+                CallEntry('def plain_method(self):'),
+                LineEntry('pass'),
+                ReturnEntry('pass'),
+                ReturnValueEntry('None'),
 
-            # Called from deleter
-            VariableEntry('self', value_regex="u?.*MyClass object at"),
-            CallEntry('def plain_method(self):'),
-            LineEntry('pass'),
-            ReturnEntry('pass'),
-            ReturnValueEntry('None'),
-        )
+                # Called from deleter
+                VariableEntry('self', value_regex="u?.*MyClass object at"),
+                CallEntry('def plain_method(self):'),
+                LineEntry('pass'),
+                ReturnEntry('pass'),
+                ReturnValueEntry('None'),
+            )
     )
 
 
@@ -1531,13 +1532,31 @@ def test_snooping_on_class_does_not_cause_base_class_to_be_snooped():
 
     output = string_io.getvalue()
     assert_output(
-        output,
-        (
-            SourcePathEntry(),
-            VariableEntry('self', value_regex="u?.*MyClass object at"),
-            CallEntry('def method_on_child_class(self):'),
-            LineEntry('self.method_on_base_class()'),
-            ReturnEntry('self.method_on_base_class()'),
-            ReturnValueEntry('None'),
-        )
+            output,
+            (
+                SourcePathEntry(),
+                VariableEntry('self', value_regex="u?.*MyClass object at"),
+                CallEntry('def method_on_child_class(self):'),
+                LineEntry('self.method_on_base_class()'),
+                ReturnEntry('self.method_on_base_class()'),
+                ReturnValueEntry('None'),
+            )
     )
+
+
+def test_see_output():
+    string_io = io.StringIO()
+
+    class A:
+        def __init__(self, a):
+            self.a = a
+
+    @pysnooper.snoop(string_io, normalize=True)
+    def stam():
+        a = A(19)
+        b = A(22)
+        res = a.a + b.a
+        return res
+
+    stam()
+    print(string_io.getvalue())

--- a/tests/test_pysnooper.py
+++ b/tests/test_pysnooper.py
@@ -157,13 +157,14 @@ def test_multi_thread_info():
     )
 
 
-def test_callable():
+@pytest.mark.parametrize("normalize", [False, True, ])
+def test_callable(normalize):
     string_io = io.StringIO()
 
     def write(msg):
         string_io.write(msg)
 
-    @pysnooper.snoop(write)
+    @pysnooper.snoop(write, normalize=normalize)
     def my_function(foo):
         x = 7
         y = 8
@@ -185,11 +186,13 @@ def test_callable():
                 LineEntry('return y + x'),
                 ReturnEntry('return y + x'),
                 ReturnValueEntry('15'),
-            )
+            ),
+            normalize=normalize,
     )
 
 
-def test_watch():
+@pytest.mark.parametrize("normalize", [False, True, ])
+def test_watch(normalize):
     class Foo(object):
         def __init__(self):
             self.x = 2
@@ -201,7 +204,7 @@ def test_watch():
             'foo.x',
             'io.__name__',
             'len(foo.__dict__["x"] * "abc")',
-    ))
+    ), normalize=normalize)
     def my_function():
         foo = Foo()
         for i in range(2):
@@ -236,17 +239,19 @@ def test_watch():
                 LineEntry(),
                 ReturnEntry(),
                 ReturnValueEntry('None')
-            )
+            ),
+            normalize=normalize,
     )
 
 
-def test_watch_explode():
+@pytest.mark.parametrize("normalize", [False, True, ])
+def test_watch_explode(normalize):
     class Foo:
         def __init__(self, x, y):
             self.x = x
             self.y = y
 
-    @pysnooper.snoop(watch_explode=('_d', '_point', 'lst + []'))
+    @pysnooper.snoop(watch_explode=('_d', '_point', 'lst + []'), normalize=normalize)
     def my_function():
         _d = {'a': 1, 'b': 2, 'c': 'ignore'}
         _point = Foo(x=3, y=4)
@@ -285,11 +290,13 @@ def test_watch_explode():
                 VariableEntry('lst + []'),
                 ReturnEntry(),
                 ReturnValueEntry('None')
-            )
+            ),
+            normalize=normalize,
     )
 
 
-def test_variables_classes():
+@pytest.mark.parametrize("normalize", [False, True, ])
+def test_variables_classes(normalize):
     class WithSlots(object):
         __slots__ = ('x', 'y')
 
@@ -302,7 +309,7 @@ def test_variables_classes():
             pysnooper.Attrs('_d'),  # doesn't have attributes
             pysnooper.Attrs('_s'),
             pysnooper.Indices('_lst')[-3:],
-    ))
+    ), normalize=normalize)
     def my_function():
         _d = {'a': 1, 'b': 2, 'c': 'ignore'}
         _s = WithSlots()
@@ -334,11 +341,13 @@ def test_variables_classes():
                 VariableEntry('_lst[999]', '999'),
                 ReturnEntry(),
                 ReturnValueEntry('None')
-            )
+            ),
+            normalize=normalize,
     )
 
 
-def test_single_watch_no_comma():
+@pytest.mark.parametrize("normalize", [False, True, ])
+def test_single_watch_no_comma(normalize):
     class Foo(object):
         def __init__(self):
             self.x = 2
@@ -346,7 +355,7 @@ def test_single_watch_no_comma():
         def square(self):
             self.x **= 2
 
-    @pysnooper.snoop(watch='foo')
+    @pysnooper.snoop(watch='foo', normalize=normalize)
     def my_function():
         foo = Foo()
         for i in range(2):
@@ -374,12 +383,14 @@ def test_single_watch_no_comma():
                 LineEntry(),
                 ReturnEntry(),
                 ReturnValueEntry('None')
-            )
+            ),
+            normalize=normalize,
     )
 
 
-def test_long_variable():
-    @pysnooper.snoop()
+@pytest.mark.parametrize("normalize", [False, True, ])
+def test_long_variable(normalize):
+    @pysnooper.snoop(normalize=normalize)
     def my_function():
         foo = list(range(1000))
         return foo
@@ -400,12 +411,14 @@ def test_long_variable():
                 LineEntry(),
                 ReturnEntry(),
                 ReturnValueEntry(value_regex=regex)
-            )
+            ),
+            normalize=normalize,
     )
 
 
-def test_long_variable_with_custom_max_variable_length():
-    @pysnooper.snoop(max_variable_length=200)
+@pytest.mark.parametrize("normalize", [False, True, ])
+def test_long_variable_with_custom_max_variable_length(normalize):
+    @pysnooper.snoop(max_variable_length=200, normalize=normalize)
     def my_function():
         foo = list(range(1000))
         return foo
@@ -426,12 +439,14 @@ def test_long_variable_with_custom_max_variable_length():
                 LineEntry(),
                 ReturnEntry(),
                 ReturnValueEntry(value_regex=regex)
-            )
+            ),
+            normalize=normalize,
     )
 
 
-def test_long_variable_with_infinite_max_variable_length():
-    @pysnooper.snoop(max_variable_length=None)
+@pytest.mark.parametrize("normalize", [False, True, ])
+def test_long_variable_with_infinite_max_variable_length(normalize):
+    @pysnooper.snoop(max_variable_length=None, normalize=normalize)
     def my_function():
         foo = list(range(1000))
         return foo
@@ -452,16 +467,18 @@ def test_long_variable_with_infinite_max_variable_length():
                 LineEntry(),
                 ReturnEntry(),
                 ReturnValueEntry(value_regex=regex)
-            )
+            ),
+            normalize=normalize,
     )
 
 
-def test_repr_exception():
+@pytest.mark.parametrize("normalize", [False, True, ])
+def test_repr_exception(normalize):
     class Bad(object):
         def __repr__(self):
             1 / 0
 
-    @pysnooper.snoop()
+    @pysnooper.snoop(normalize=normalize)
     def my_function():
         bad = Bad()
 
@@ -480,11 +497,13 @@ def test_repr_exception():
                 VariableEntry('bad', value='REPR FAILED'),
                 ReturnEntry(),
                 ReturnValueEntry('None')
-            )
+            ),
+            normalize=normalize,
     )
 
 
-def test_depth():
+@pytest.mark.parametrize("normalize", [False, True, ])
+def test_depth(normalize):
     string_io = io.StringIO()
 
     def f4(x4):
@@ -499,7 +518,7 @@ def test_depth():
         result2 = f3(x2)
         return result2
 
-    @pysnooper.snoop(string_io, depth=3)
+    @pysnooper.snoop(string_io, depth=3, normalize=normalize)
     def f1(x1):
         result1 = f2(x1)
         return result1
@@ -540,16 +559,18 @@ def test_depth():
                 LineEntry(),
                 ReturnEntry(),
                 ReturnValueEntry('20'),
-            )
+            ),
+            normalize=normalize,
     )
 
 
-def test_method_and_prefix():
+@pytest.mark.parametrize("normalize", [False, True, ])
+def test_method_and_prefix(normalize):
     class Baz(object):
         def __init__(self):
             self.x = 2
 
-        @pysnooper.snoop(watch=('self.x',), prefix='ZZZ')
+        @pysnooper.snoop(watch=('self.x',), prefix='ZZZ', normalize=normalize)
         def square(self):
             foo = 7
             self.x **= 2
@@ -578,15 +599,17 @@ def test_method_and_prefix():
                 ReturnEntry(prefix='ZZZ'),
                 ReturnValueEntry(prefix='ZZZ'),
             ),
-            prefix='ZZZ'
+            prefix='ZZZ',
+            normalize=normalize,
     )
 
 
-def test_file_output():
+@pytest.mark.parametrize("normalize", [True, False, ])
+def test_file_output(normalize):
     with mini_toolbox.create_temp_folder(prefix='pysnooper') as folder:
         path = folder / 'foo.log'
 
-        @pysnooper.snoop(path)
+        @pysnooper.snoop(path, normalize=normalize)
         def my_function(_foo):
             x = 7
             y = 8
@@ -609,18 +632,20 @@ def test_file_output():
                     LineEntry('return y + x'),
                     ReturnEntry('return y + x'),
                     ReturnValueEntry('15'),
-                )
+                ),
+                normalize=normalize,
         )
 
 
-def test_confusing_decorator_lines():
+@pytest.mark.parametrize("normalize", [True, False, ])
+def test_confusing_decorator_lines(normalize):
     string_io = io.StringIO()
 
     def empty_decorator(function):
         return function
 
     @empty_decorator
-    @pysnooper.snoop(string_io,
+    @pysnooper.snoop(string_io, normalize=normalize,
                      depth=2)  # Multi-line decorator for extra confusion!
     @empty_decorator
     @empty_decorator
@@ -652,13 +677,15 @@ def test_confusing_decorator_lines():
                 # back in my_function
                 ReturnEntry(),
                 ReturnValueEntry('15'),
-            )
+            ),
+            normalize=normalize,
     )
 
 
-def test_lambda():
+@pytest.mark.parametrize("normalize", [True, False, ])
+def test_lambda(normalize):
     string_io = io.StringIO()
-    my_function = pysnooper.snoop(string_io)(lambda x: x ** 2)
+    my_function = pysnooper.snoop(string_io, normalize=normalize)(lambda x: x ** 2)
     result = my_function(7)
     assert result == 49
     output = string_io.getvalue()
@@ -671,7 +698,8 @@ def test_lambda():
                 LineEntry(source_regex='^my_function = pysnooper.*'),
                 ReturnEntry(source_regex='^my_function = pysnooper.*'),
                 ReturnValueEntry('49'),
-            )
+            ),
+            normalize=normalize,
     )
 
 
@@ -815,9 +843,10 @@ def test_needs_parentheses():
     assert needs_parentheses('x if z else y')
 
 
-def test_with_block():
+@pytest.mark.parametrize("normalize", [True, False, ])
+def test_with_block(normalize):
     # Testing that a single Tracer can handle many mixed uses
-    snoop = pysnooper.snoop()
+    snoop = pysnooper.snoop(normalize=normalize)
 
     def foo(x):
         if x == 0:
@@ -935,10 +964,12 @@ def test_with_block():
                 ReturnEntry('qux()'),
                 ReturnValueEntry('None'),
             ),
+            normalize=normalize,
     )
 
 
-def test_with_block_depth():
+@pytest.mark.parametrize("normalize", [True, False, ])
+def test_with_block_depth(normalize):
     string_io = io.StringIO()
 
     def f4(x4):
@@ -955,7 +986,7 @@ def test_with_block_depth():
 
     def f1(x1):
         str(3)
-        with pysnooper.snoop(string_io, depth=3):
+        with pysnooper.snoop(string_io, depth=3, normalize=normalize):
             result1 = f2(x1)
         return result1
 
@@ -966,6 +997,7 @@ def test_with_block_depth():
             output,
             (
                 SourcePathEntry(),
+                VariableEntry(),
                 VariableEntry(),
                 VariableEntry(),
                 VariableEntry(),
@@ -990,11 +1022,13 @@ def test_with_block_depth():
                 LineEntry(),
                 ReturnEntry(),
                 ReturnValueEntry('20'),
-            )
+            ),
+            normalize=normalize,
     )
 
 
-def test_cellvars():
+@pytest.mark.parametrize("normalize", [True, False, ])
+def test_cellvars(normalize):
     string_io = io.StringIO()
 
     def f2(a):
@@ -1011,7 +1045,7 @@ def test_cellvars():
         return f3(a)
 
     def f1(a):
-        with pysnooper.snoop(string_io, depth=4):
+        with pysnooper.snoop(string_io, depth=4, normalize=normalize):
             result1 = f2(a)
         return result1
 
@@ -1022,6 +1056,7 @@ def test_cellvars():
             output,
             (
                 SourcePathEntry(),
+                VariableEntry(),
                 VariableEntry(),
                 VariableEntry(),
                 VariableEntry(),
@@ -1056,11 +1091,13 @@ def test_cellvars():
                 ReturnValueEntry(),
                 ReturnEntry(),
                 ReturnValueEntry(),
-            )
+            ),
+            normalize=normalize,
     )
 
 
-def test_var_order():
+@pytest.mark.parametrize("normalize", [True, False, ])
+def test_var_order(normalize):
     string_io = io.StringIO()
 
     def f(one, two, three, four):
@@ -1070,7 +1107,7 @@ def test_var_order():
 
         five, six, seven = 5, 6, 7
 
-    with pysnooper.snoop(string_io, depth=2):
+    with pysnooper.snoop(string_io, depth=2, normalize=normalize):
         result = f(1, 2, 3, 4)
 
     output = string_io.getvalue()
@@ -1078,6 +1115,7 @@ def test_var_order():
             output,
             (
                 SourcePathEntry(),
+                VariableEntry(),
                 VariableEntry(),
                 VariableEntry(),
 
@@ -1100,7 +1138,8 @@ def test_var_order():
                 VariableEntry("seven", "7"),
                 ReturnEntry(),
                 ReturnValueEntry(),
-            )
+            ),
+            normalize=normalize,
     )
 
 
@@ -1206,7 +1245,8 @@ def test_generator():
     )
 
 
-def test_custom_repr():
+@pytest.mark.parametrize("normalize", [True, False, ])
+def test_custom_repr(normalize):
     string_io = io.StringIO()
 
     def large(l):
@@ -1221,10 +1261,14 @@ def test_custom_repr():
     def evil_condition(x):
         return large(x) or isinstance(x, dict)
 
-    @pysnooper.snoop(string_io, custom_repr=(
-            (large, print_list_size),
-            (dict, print_dict),
-            (evil_condition, lambda x: 'I am evil')))
+    @pysnooper.snoop(
+            string_io,
+            custom_repr=(
+                    (large, print_list_size), (dict, print_dict),
+                    (evil_condition, lambda x: 'I am evil')
+            ),
+            normalize=normalize,
+    )
     def sum_to_x(x):
         l = list(range(x))
         a = {'1': 1, '2': 2}
@@ -1246,14 +1290,20 @@ def test_custom_repr():
                 LineEntry(),
                 ReturnEntry(),
                 ReturnValueEntry('49995000'),
-            )
+            ),
+            normalize=normalize,
     )
 
 
-def test_custom_repr_single():
+@pytest.mark.parametrize("normalize", [True, False, ])
+def test_custom_repr_single(normalize):
     string_io = io.StringIO()
 
-    @pysnooper.snoop(string_io, custom_repr=(list, lambda l: 'foofoo!'))
+    @pysnooper.snoop(
+            string_io,
+            normalize=normalize,
+            custom_repr=(list, lambda l: 'foofoo!'),
+    )
     def sum_to_x(x):
         l = list(range(x))
         return 7
@@ -1272,7 +1322,8 @@ def test_custom_repr_single():
                 LineEntry(),
                 ReturnEntry(),
                 ReturnValueEntry('7'),
-            )
+            ),
+            normalize=normalize,
     )
 
 
@@ -1295,10 +1346,11 @@ def test_disable():
     assert not output
 
 
-def test_class():
+@pytest.mark.parametrize("normalize", [True, False, ])
+def test_class(normalize):
     string_io = io.StringIO()
 
-    @pysnooper.snoop(string_io)
+    @pysnooper.snoop(string_io, normalize=normalize)
     class MyClass(object):
         def __init__(self):
             self.x = 7
@@ -1315,12 +1367,12 @@ def test_class():
             output,
             (
                 SourcePathEntry(),
-                VariableEntry('self', value_regex="u?.+MyClass object at"),
+                VariableEntry('self', value_regex="u?.+MyClass object"),
                 CallEntry('def __init__(self):'),
                 LineEntry('self.x = 7'),
                 ReturnEntry('self.x = 7'),
                 ReturnValueEntry('None'),
-                VariableEntry('self', value_regex="u?.+MyClass object at"),
+                VariableEntry('self', value_regex="u?.+MyClass object"),
                 VariableEntry('foo', value_regex="u?'baba'"),
                 CallEntry('def my_method(self, foo):'),
                 LineEntry('y = 8'),
@@ -1328,11 +1380,13 @@ def test_class():
                 LineEntry('return y + self.x'),
                 ReturnEntry('return y + self.x'),
                 ReturnValueEntry('15'),
-            )
+            ),
+            normalize=normalize,
     )
 
 
-def test_class_with_decorated_method():
+@pytest.mark.parametrize("normalize", [True, False, ])
+def test_class_with_decorated_method(normalize):
     string_io = io.StringIO()
 
     def decorator(function):
@@ -1342,7 +1396,7 @@ def test_class_with_decorated_method():
 
         return wrapper
 
-    @pysnooper.snoop(string_io)
+    @pysnooper.snoop(string_io, normalize=normalize)
     class MyClass(object):
         def __init__(self):
             self.x = 7
@@ -1360,25 +1414,27 @@ def test_class_with_decorated_method():
             output,
             (
                 SourcePathEntry(),
-                VariableEntry('self', value_regex="u?.+MyClass object at"),
+                VariableEntry('self', value_regex="u?.+MyClass object"),
                 CallEntry('def __init__(self):'),
                 LineEntry('self.x = 7'),
                 ReturnEntry('self.x = 7'),
                 ReturnValueEntry('None'),
                 VariableEntry('args', value_regex=r"\(<.+>, 'baba'\)"),
                 VariableEntry('kwargs', value_regex=r"\{\}"),
-                VariableEntry('function', value_regex="u?.+my_method at"),
+                VariableEntry('function', value_regex="u?.+my_method"),
                 CallEntry('def wrapper(*args, **kwargs):'),
                 LineEntry('result = function(*args, **kwargs)'),
                 VariableEntry('result', '15'),
                 LineEntry('return result'),
                 ReturnEntry('return result'),
                 ReturnValueEntry('15'),
-            )
+            ),
+            normalize=normalize,
     )
 
 
-def test_class_with_decorated_method_and_snoop_applied_to_method():
+@pytest.mark.parametrize("normalize", [True, False, ])
+def test_class_with_decorated_method_and_snoop_applied_to_method(normalize):
     string_io = io.StringIO()
 
     def decorator(function):
@@ -1388,13 +1444,13 @@ def test_class_with_decorated_method_and_snoop_applied_to_method():
 
         return wrapper
 
-    @pysnooper.snoop(string_io)
+    @pysnooper.snoop(string_io, normalize=normalize)
     class MyClass(object):
         def __init__(self):
             self.x = 7
 
         @decorator
-        @pysnooper.snoop(string_io)
+        @pysnooper.snoop(string_io, normalize=normalize)
         def my_method(self, foo):
             y = 8
             return y + self.x
@@ -1407,18 +1463,18 @@ def test_class_with_decorated_method_and_snoop_applied_to_method():
             output,
             (
                 SourcePathEntry(),
-                VariableEntry('self', value_regex="u?.*MyClass object at"),
+                VariableEntry('self', value_regex="u?.*MyClass object"),
                 CallEntry('def __init__(self):'),
                 LineEntry('self.x = 7'),
                 ReturnEntry('self.x = 7'),
                 ReturnValueEntry('None'),
                 VariableEntry('args', value_regex=r"u?\(<.+>, 'baba'\)"),
                 VariableEntry('kwargs', value_regex=r"u?\{\}"),
-                VariableEntry('function', value_regex="u?.*my_method at"),
+                VariableEntry('function', value_regex="u?.*my_method"),
                 CallEntry('def wrapper(*args, **kwargs):'),
                 LineEntry('result = function(*args, **kwargs)'),
                 SourcePathEntry(),
-                VariableEntry('self', value_regex="u?.*MyClass object at"),
+                VariableEntry('self', value_regex="u?.*MyClass object"),
                 VariableEntry('foo', value_regex="u?'baba'"),
                 CallEntry('def my_method(self, foo):'),
                 LineEntry('y = 8'),
@@ -1430,14 +1486,16 @@ def test_class_with_decorated_method_and_snoop_applied_to_method():
                 LineEntry('return result'),
                 ReturnEntry('return result'),
                 ReturnValueEntry('15'),
-            )
+            ),
+            normalize=normalize,
     )
 
 
-def test_class_with_property():
+@pytest.mark.parametrize("normalize", [True, False, ])
+def test_class_with_property(normalize):
     string_io = io.StringIO()
 
-    @pysnooper.snoop(string_io)
+    @pysnooper.snoop(string_io, normalize=normalize)
     class MyClass(object):
         def __init__(self):
             self._x = 0
@@ -1479,37 +1537,39 @@ def test_class_with_property():
             output,
             (
                 SourcePathEntry(),
-                VariableEntry('self', value_regex="u?.*MyClass object at"),
+                VariableEntry('self', value_regex="u?.*MyClass object"),
                 CallEntry('def __init__(self):'),
                 LineEntry('self._x = 0'),
                 ReturnEntry('self._x = 0'),
                 ReturnValueEntry('None'),
 
                 # Called from getter
-                VariableEntry('self', value_regex="u?.*MyClass object at"),
+                VariableEntry('self', value_regex="u?.*MyClass object"),
                 CallEntry('def plain_method(self):'),
                 LineEntry('pass'),
                 ReturnEntry('pass'),
                 ReturnValueEntry('None'),
 
                 # Called from setter
-                VariableEntry('self', value_regex="u?.*MyClass object at"),
+                VariableEntry('self', value_regex="u?.*MyClass object"),
                 CallEntry('def plain_method(self):'),
                 LineEntry('pass'),
                 ReturnEntry('pass'),
                 ReturnValueEntry('None'),
 
                 # Called from deleter
-                VariableEntry('self', value_regex="u?.*MyClass object at"),
+                VariableEntry('self', value_regex="u?.*MyClass object"),
                 CallEntry('def plain_method(self):'),
                 LineEntry('pass'),
                 ReturnEntry('pass'),
                 ReturnValueEntry('None'),
-            )
+            ),
+            normalize=normalize,
     )
 
 
-def test_snooping_on_class_does_not_cause_base_class_to_be_snooped():
+@pytest.mark.parametrize("normalize", [True, False, ])
+def test_snooping_on_class_does_not_cause_base_class_to_be_snooped(normalize):
     string_io = io.StringIO()
 
     class UnsnoopedBaseClass(object):
@@ -1519,7 +1579,7 @@ def test_snooping_on_class_does_not_cause_base_class_to_be_snooped():
         def method_on_base_class(self):
             self.method_on_base_class_was_called = True
 
-    @pysnooper.snoop(string_io)
+    @pysnooper.snoop(string_io, normalize=normalize)
     class MyClass(UnsnoopedBaseClass):
         def method_on_child_class(self):
             self.method_on_base_class()
@@ -1535,28 +1595,105 @@ def test_snooping_on_class_does_not_cause_base_class_to_be_snooped():
             output,
             (
                 SourcePathEntry(),
-                VariableEntry('self', value_regex="u?.*MyClass object at"),
+                VariableEntry('self', value_regex="u?.*MyClass object"),
                 CallEntry('def method_on_child_class(self):'),
                 LineEntry('self.method_on_base_class()'),
                 ReturnEntry('self.method_on_base_class()'),
                 ReturnValueEntry('None'),
-            )
+            ),
+            normalize=normalize,
     )
 
 
-def test_see_output():
+def test_normalize():
     string_io = io.StringIO()
 
     class A:
         def __init__(self, a):
             self.a = a
 
-    @pysnooper.snoop(string_io, normalize=False)
-    def stam():
+    @pysnooper.snoop(string_io, normalize=True)
+    def add():
         a = A(19)
         b = A(22)
         res = a.a + b.a
         return res
 
-    stam()
-    print(string_io.getvalue())
+    add()
+    output = string_io.getvalue()
+    assert_output(
+            output,
+            (
+                SourcePathEntry('test_pysnooper.py'),
+                VariableEntry('A', value_regex=r"<class .*<locals>.A"),
+                CallEntry('def add():'),
+                LineEntry('a = A(19)'),
+                VariableEntry('a', value_regex=r"<.*<locals>\.A object>"),
+                LineEntry('b = A(22)'),
+                VariableEntry('b', value_regex=r"<.*<locals>\.A object>"),
+                LineEntry('res = a.a + b.a'),
+                VariableEntry('res', value="41"),
+                LineEntry('return res'),
+                ReturnEntry('return res'),
+                ReturnValueEntry('41'),
+            )
+    )
+
+
+def test_normalize_prefix():
+    string_io = io.StringIO()
+    _prefix = 'ZZZZ'
+
+    class A:
+        def __init__(self, a):
+            self.a = a
+
+    @pysnooper.snoop(string_io, normalize=True, prefix=_prefix)
+    def add():
+        a = A(19)
+        b = A(22)
+        res = a.a + b.a
+        return res
+
+    add()
+    output = string_io.getvalue()
+    assert_output(
+            output,
+            (
+                SourcePathEntry('test_pysnooper.py', prefix=_prefix),
+                VariableEntry('A', value_regex=r"<class .*<locals>.A", prefix=_prefix),
+                CallEntry('def add():', prefix=_prefix),
+                LineEntry('a = A(19)', prefix=_prefix),
+                VariableEntry('a', value_regex=r"<.*<locals>\.A object>", prefix=_prefix),
+                LineEntry('b = A(22)', prefix=_prefix),
+                VariableEntry('b', value_regex=r"<.*<locals>\.A object>", prefix=_prefix),
+                LineEntry('res = a.a + b.a', prefix=_prefix),
+                VariableEntry('res', value="41", prefix=_prefix),
+                LineEntry('return res', prefix=_prefix),
+                ReturnEntry('return res', prefix=_prefix),
+                ReturnValueEntry('41', prefix=_prefix),
+            )
+    )
+
+
+def test_normalize_thread_info():
+    string_io = io.StringIO()
+
+    class A:
+        def __init__(self, a):
+            self.a = a
+
+    @pysnooper.snoop(string_io, normalize=True, thread_info=True)
+    def add():
+        a = A(19)
+        b = A(22)
+        res = a.a + b.a
+        return res
+
+    try:
+        add()
+    except NotImplementedError:
+        # should be thrown when using both flags
+        pass
+    else:
+        assert False, "should throw NotImplementedError"

--- a/tests/test_pysnooper.py
+++ b/tests/test_pysnooper.py
@@ -1551,7 +1551,7 @@ def test_see_output():
         def __init__(self, a):
             self.a = a
 
-    @pysnooper.snoop(string_io, normalize=True)
+    @pysnooper.snoop(string_io, normalize=False)
     def stam():
         a = A(19)
         b = A(22)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,9 +1,11 @@
 # Copyright 2019 Ram Rachum and collaborators.
 # This program is distributed under the MIT license.
-
+import os
 import re
 import abc
 import inspect
+
+from pysnooper.utils import DEFAULT_REPR_RE
 
 try:
     from itertools import zip_longest
@@ -202,10 +204,10 @@ class _BaseEventEntry(_BaseEntry):
         if source is not None:
             assert source_regex is None
         self.line_pattern = re.compile(
-            r"""^%s(?P<indent>(?: {4})*)[0-9:.]{15} """
-            r"""(?P<thread_info>[0-9]+-[0-9A-Za-z_-]+[ ]+)?"""
-            r"""(?P<event_name>[a-z_]*) +(?P<line_number>[0-9]*) """
-            r"""+(?P<source>.*)$""" % (re.escape(self.prefix,))
+                r"""^%s(?P<indent>(?: {4})*)(?:[0-9:.]{15})? """
+                r"""(?P<thread_info>[0-9]+-[0-9A-Za-z_-]+[ ]+)?"""
+                r"""(?P<event_name>[a-z_]*) +(?P<line_number>[0-9]*) """
+                r"""+(?P<source>.*)$""" % (re.escape(self.prefix, ))
         )
 
         self.source = source
@@ -269,13 +271,34 @@ class OutputFailure(Exception):
     pass
 
 
-def assert_output(output, expected_entries, prefix=None):
+def verify_normalize(lines, prefix):
+    time_re = re.compile(r"[0-9:.]{15}")
+    src_re = re.compile(r'^(?: *)Source path:\.\.\. (.*)$')
+    for line in lines:
+        if DEFAULT_REPR_RE.search(line):
+            msg = "normalize is active, memory address should not appear"
+            raise OutputFailure(line, msg)
+        no_prefix = line.replace(prefix if prefix else '', '').strip()
+        if time_re.match(no_prefix):
+            msg = "normalize is active, time should not appear"
+            raise OutputFailure(line, msg)
+        m = src_re.match(line)
+        if m:
+            if not os.path.basename(m.group(1)) == m.group(1):
+                msg = "normalize is active, path should be only basename"
+                raise OutputFailure(line, msg)
+
+
+def assert_output(output, expected_entries, prefix=None, normalize=False):
     lines = tuple(filter(None, output.split('\n')))
 
     if prefix is not None:
         for line in lines:
             if not line.startswith(prefix):
                 raise OutputFailure(line)
+
+    if normalize:
+        verify_normalize(lines, prefix)
 
     any_mismatch = False
     result = ''


### PR DESCRIPTION
normalizing output - removing machine specific data:
- absolute paths are replaced with the `basename` of the path.
- time stamps are removed.
- default (CPython) reprs of the form <.... at 0x[0-9a-fA-F] > will not contain the 'at 0x...' ending.

tests:
- normalization does not affect the original test results so every test now runs with `normalize=True`
and `normalize=False` to preserve compatability.
- `assert_output` can now verify the output of a normalized trace.