### PR TITLE
Add elapsed time and elapsed_time format option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,18 +72,18 @@ Or if you don't want to trace an entire function, you can wrap the relevant part
 import pysnooper
 import random
 
-def foo():
+def foo(relative_time=False):
     lst = []
     for i in range(10):
         lst.append(random.randrange(1, 1000))
 
-    with pysnooper.snoop():
+    with pysnooper.snoop(relative_time=relative_time):
         lower = min(lst)
         upper = max(lst)
         mid = (lower + upper) / 2
         print(lower, mid, upper)
 
-foo()
+foo(False)
 ```
 
 which outputs something like:
@@ -99,6 +99,27 @@ New var:....... upper = 832
 74 453.0 832
 New var:....... mid = 453.0
 09:37:35.882486 line        13         print(lower, mid, upper)
+Total elapsed time: 00:00:00.000344
+```
+
+If `relative_time` is `True`, print time format will be relative.
+
+```python
+import pysnooper
+import random
+
+def foo(relative_time=False):
+    lst = []
+    for i in range(10):
+        lst.append(random.randrange(1, 1000))
+
+    with pysnooper.snoop(relative_time=relative_time):
+        lower = min(lst)
+        upper = max(lst)
+        mid = (lower + upper) / 2
+        print(lower, mid, upper)
+
+foo(True)
 ```
 
 # Features #

--- a/README.md
+++ b/README.md
@@ -72,12 +72,12 @@ Or if you don't want to trace an entire function, you can wrap the relevant part
 import pysnooper
 import random
 
-def foo(relative_time=False):
+def foo(elapsed_time=False):
     lst = []
     for i in range(10):
         lst.append(random.randrange(1, 1000))
 
-    with pysnooper.snoop(relative_time=relative_time):
+    with pysnooper.snoop(elapsed_time=elapsed_time):
         lower = min(lst)
         upper = max(lst)
         mid = (lower + upper) / 2
@@ -102,18 +102,18 @@ New var:....... mid = 453.0
 Total elapsed time: 00:00:00.000344
 ```
 
-If `relative_time` is `True`, print time format will be relative.
+If `elapsed_time` is `True`, print elapsed time format.
 
 ```python
 import pysnooper
 import random
 
-def foo(relative_time=False):
+def foo(elapsed_time=False):
     lst = []
     for i in range(10):
         lst.append(random.randrange(1, 1000))
 
-    with pysnooper.snoop(relative_time=relative_time):
+    with pysnooper.snoop(elapsed_time=elapsed_time):
         lower = min(lst)
         upper = max(lst)
         mid = (lower + upper) / 2

--- a/pysnooper/pycompat.py
+++ b/pysnooper/pycompat.py
@@ -80,3 +80,9 @@ else:
         return result
 
 
+def timedelta_isoformat(timedelta, timespec='microseconds'):
+    assert isinstance(timedelta, datetime_module.timedelta)
+    if timespec != 'microseconds':
+        raise NotImplementedError
+    time = (datetime_module.datetime.min + timedelta).time()
+    return time_isoformat(time, timespec)

--- a/pysnooper/pycompat.py
+++ b/pysnooper/pycompat.py
@@ -90,9 +90,6 @@ else:
         return datetime_module.time(hour, minute, second, microsecond)
 
 
-def timedelta_isoformat(timedelta, timespec='microseconds'):
-    assert isinstance(timedelta, datetime_module.timedelta)
-    if timespec != 'microseconds':
-        raise NotImplementedError
+def timedelta_isoformat(timedelta):
     time = (datetime_module.datetime.min + timedelta).time()
-    return time_isoformat(time, timespec)
+    return time_isoformat(time)

--- a/pysnooper/pycompat.py
+++ b/pysnooper/pycompat.py
@@ -90,6 +90,6 @@ else:
         return datetime_module.time(hour, minute, second, microsecond)
 
 
-def timedelta_isoformat(timedelta):
+def timedelta_isoformat(timedelta, timespec='microseconds'):
     time = (datetime_module.datetime.min + timedelta).time()
-    return time_isoformat(time)
+    return time_isoformat(time, timespec)

--- a/pysnooper/pycompat.py
+++ b/pysnooper/pycompat.py
@@ -80,6 +80,16 @@ else:
         return result
 
 
+if sys.version_info[:2] >= (3, 7):
+    time_fromisoformat = datetime_module.time.fromisoformat
+else:
+    def time_fromisoformat(isoformat_str):
+        hour, minute, second, microsecond = map(
+            int,
+            isoformat_str.replace('.', ':').split(':'))
+        return datetime_module.time(hour, minute, second, microsecond)
+
+
 def timedelta_isoformat(timedelta, timespec='microseconds'):
     assert isinstance(timedelta, datetime_module.timedelta)
     if timespec != 'microseconds':

--- a/pysnooper/tracer.py
+++ b/pysnooper/tracer.py
@@ -310,9 +310,8 @@ class Tracer:
         self.target_frames.discard(calling_frame)
         self.frame_to_local_reprs.pop(calling_frame, None)
 
-        now = (datetime_module.datetime.min + (
-            datetime_module.datetime.now() - self.start_time)).time()
-        now_string = pycompat.time_isoformat(now, timespec='microseconds')
+        duration = datetime_module.datetime.now() - self.start_time
+        now_string = pycompat.timedelta_isoformat(duration, timespec='microseconds')
         self.write('Total elapsed time: {now_string}'.format(**locals()))
 
     def _is_internal_frame(self, frame):
@@ -360,11 +359,12 @@ class Tracer:
         ### Finished checking whether we should trace this line. ##############
 
         if self.relative_time:
-            now = (datetime_module.datetime.min +
-                   (datetime_module.datetime.now() - self.start_time)).time()
+            duration = datetime_module.datetime.now() - self.start_time
+            now_string = pycompat.timedelta_isoformat(
+                duration, timespec='microseconds') if not self.normalize else ' ' * 15
         else:
             now = datetime_module.datetime.now().time()
-        now_string = pycompat.time_isoformat(now, timespec='microseconds') if not self.normalize else ' ' * 15
+            now_string = pycompat.time_isoformat(now, timespec='microseconds') if not self.normalize else ' ' * 15
         line_no = frame.f_lineno
         source_path, source = get_path_and_source_from_frame(frame)
         source_path = source_path if not self.normalize else os.path.basename(source_path)

--- a/pysnooper/tracer.py
+++ b/pysnooper/tracer.py
@@ -201,7 +201,8 @@ class Tracer:
     '''
     def __init__(self, output=None, watch=(), watch_explode=(), depth=1,
                  prefix='', overwrite=False, thread_info=False, custom_repr=(),
-                 max_variable_length=100, normalize=False):
+                 max_variable_length=100, normalize=False,
+                 relative_time=False):
         self._write = get_write_function(output, overwrite)
 
         self.watch = [
@@ -227,6 +228,7 @@ class Tracer:
         self.last_source_path = None
         self.max_variable_length = max_variable_length
         self.normalize = normalize
+        self.relative_time = relative_time
 
     def __call__(self, function_or_class):
         if DISABLED:
@@ -357,7 +359,11 @@ class Tracer:
         #                                                                     #
         ### Finished checking whether we should trace this line. ##############
 
-        now = datetime_module.datetime.now().time()
+        if self.relative_time:
+            now = (datetime_module.datetime.min +
+                   (datetime_module.datetime.now() - self.start_time)).time()
+        else:
+            now = datetime_module.datetime.now().time()
         now_string = pycompat.time_isoformat(now, timespec='microseconds') if not self.normalize else ' ' * 15
         line_no = frame.f_lineno
         source_path, source = get_path_and_source_from_frame(frame)

--- a/pysnooper/tracer.py
+++ b/pysnooper/tracer.py
@@ -318,7 +318,9 @@ class Tracer:
         start_time = self.start_times.pop(id(calling_frame))
         duration = datetime_module.datetime.now() - start_time
         now_string = pycompat.timedelta_isoformat(duration, timespec='microseconds')
-        self.write('Total elapsed time: {now_string}'.format(**locals()))
+        indent = ' ' * 4 * (thread_global.depth + 1)
+        self.write('{indent}Total elapsed time: {now_string}'.format(
+            **locals()))
 
     def _is_internal_frame(self, frame):
         return frame.f_code.co_filename == Tracer.__enter__.__code__.co_filename

--- a/pysnooper/tracer.py
+++ b/pysnooper/tracer.py
@@ -374,7 +374,7 @@ class Tracer:
                 start_time = self.start_times[frame]
             duration = datetime_module.datetime.now() - start_time
             now_string = pycompat.timedelta_isoformat(
-                duration) if not self.normalize else ' ' * 15
+                duration, timespec='microseconds') if not self.normalize else ' ' * 15
         else:
             now = datetime_module.datetime.now().time()
             now_string = pycompat.time_isoformat(now, timespec='microseconds') if not self.normalize else ' ' * 15

--- a/pysnooper/tracer.py
+++ b/pysnooper/tracer.py
@@ -317,7 +317,7 @@ class Tracer:
 
         start_time = self.start_times.pop(-1)
         duration = datetime_module.datetime.now() - start_time
-        now_string = pycompat.timedelta_isoformat(duration, timespec='microseconds')
+        now_string = pycompat.timedelta_isoformat(duration)
         indent = ' ' * 4 * (thread_global.depth + 1)
         self.write('{indent}Total elapsed time: {now_string}'.format(
             **locals()))

--- a/pysnooper/tracer.py
+++ b/pysnooper/tracer.py
@@ -296,6 +296,7 @@ class Tracer:
             'original_trace_functions', []
         )
         stack.append(sys.gettrace())
+        self.start_time = datetime_module.datetime.now()
         sys.settrace(self.trace)
 
     def __exit__(self, exc_type, exc_value, exc_traceback):
@@ -306,6 +307,11 @@ class Tracer:
         calling_frame = inspect.currentframe().f_back
         self.target_frames.discard(calling_frame)
         self.frame_to_local_reprs.pop(calling_frame, None)
+
+        now = (datetime_module.datetime.min + (
+            datetime_module.datetime.now() - self.start_time)).time()
+        now_string = pycompat.time_isoformat(now, timespec='microseconds')
+        self.write('Total elapsed time: {now_string}'.format(**locals()))
 
     def _is_internal_frame(self, frame):
         return frame.f_code.co_filename == Tracer.__enter__.__code__.co_filename

--- a/pysnooper/tracer.py
+++ b/pysnooper/tracer.py
@@ -310,9 +310,10 @@ class Tracer:
         self.target_frames.discard(calling_frame)
         self.frame_to_local_reprs.pop(calling_frame, None)
 
-        duration = datetime_module.datetime.now() - self.start_time
-        now_string = pycompat.timedelta_isoformat(duration, timespec='microseconds')
-        self.write('Total elapsed time: {now_string}'.format(**locals()))
+        if thread_global.depth == -1:
+            duration = datetime_module.datetime.now() - self.start_time
+            now_string = pycompat.timedelta_isoformat(duration, timespec='microseconds')
+            self.write('Total elapsed time: {now_string}'.format(**locals()))
 
     def _is_internal_frame(self, frame):
         return frame.f_code.co_filename == Tracer.__enter__.__code__.co_filename

--- a/pysnooper/tracer.py
+++ b/pysnooper/tracer.py
@@ -217,6 +217,7 @@ class Tracer:
              for v in utils.ensure_tuple(watch_explode)
         ]
         self.frame_to_local_reprs = {}
+        self.start_times = {}
         self.depth = depth
         self.prefix = prefix
         self.thread_info = thread_info
@@ -302,7 +303,7 @@ class Tracer:
             'original_trace_functions', []
         )
         stack.append(sys.gettrace())
-        self.start_time = datetime_module.datetime.now()
+        self.start_times[id(calling_frame)] = datetime_module.datetime.now()
         sys.settrace(self.trace)
 
     def __exit__(self, exc_type, exc_value, exc_traceback):
@@ -314,10 +315,10 @@ class Tracer:
         self.target_frames.discard(calling_frame)
         self.frame_to_local_reprs.pop(calling_frame, None)
 
-        if thread_global.depth == -1:
-            duration = datetime_module.datetime.now() - self.start_time
-            now_string = pycompat.timedelta_isoformat(duration, timespec='microseconds')
-            self.write('Total elapsed time: {now_string}'.format(**locals()))
+        start_time = self.start_times.pop(id(calling_frame))
+        duration = datetime_module.datetime.now() - start_time
+        now_string = pycompat.timedelta_isoformat(duration, timespec='microseconds')
+        self.write('Total elapsed time: {now_string}'.format(**locals()))
 
     def _is_internal_frame(self, frame):
         return frame.f_code.co_filename == Tracer.__enter__.__code__.co_filename
@@ -364,7 +365,9 @@ class Tracer:
         ### Finished checking whether we should trace this line. ##############
 
         if self.elapsed_time:
-            duration = datetime_module.datetime.now() - self.start_time
+            calling_frame = frame.f_back
+            duration = datetime_module.datetime.now() - self.start_times[
+                id(calling_frame)]
             now_string = pycompat.timedelta_isoformat(
                 duration, timespec='microseconds') if not self.normalize else ' ' * 15
         else:

--- a/pysnooper/tracer.py
+++ b/pysnooper/tracer.py
@@ -198,11 +198,15 @@ class Tracer:
 
     You can also use `max_variable_length=None` to never truncate them.
 
+    Print time in elapsed time format::
+
+        @pysnooper.snoop(elapsed_time=True)
+
     '''
     def __init__(self, output=None, watch=(), watch_explode=(), depth=1,
                  prefix='', overwrite=False, thread_info=False, custom_repr=(),
                  max_variable_length=100, normalize=False,
-                 relative_time=False):
+                 elapsed_time=False):
         self._write = get_write_function(output, overwrite)
 
         self.watch = [
@@ -228,7 +232,7 @@ class Tracer:
         self.last_source_path = None
         self.max_variable_length = max_variable_length
         self.normalize = normalize
-        self.relative_time = relative_time
+        self.elapsed_time = elapsed_time
 
     def __call__(self, function_or_class):
         if DISABLED:
@@ -359,7 +363,7 @@ class Tracer:
         #                                                                     #
         ### Finished checking whether we should trace this line. ##############
 
-        if self.relative_time:
+        if self.elapsed_time:
             duration = datetime_module.datetime.now() - self.start_time
             now_string = pycompat.timedelta_isoformat(
                 duration, timespec='microseconds') if not self.normalize else ' ' * 15

--- a/pysnooper/tracer.py
+++ b/pysnooper/tracer.py
@@ -368,7 +368,7 @@ class Tracer:
         if self.elapsed_time:
             duration = datetime_module.datetime.now() - self.start_times[-1]
             now_string = pycompat.timedelta_isoformat(
-                duration, timespec='microseconds') if not self.normalize else ' ' * 15
+                duration) if not self.normalize else ' ' * 15
         else:
             now = datetime_module.datetime.now().time()
             now_string = pycompat.time_isoformat(now, timespec='microseconds') if not self.normalize else ' ' * 15

--- a/tests/samples/exception.py
+++ b/tests/samples/exception.py
@@ -46,4 +46,5 @@ TypeError: bad
 12:18:08.018787 line        21         pass
 12:18:08.018813 return      21         pass
 Return value:.. None
+Total elapsed time: 00:00:00.000885
 '''

--- a/tests/samples/indentation.py
+++ b/tests/samples/indentation.py
@@ -38,6 +38,7 @@ Source path:... Whatever
             Return value:.. None
         21:10:42.299509 return      19     f5()
         Return value:.. None
+        Total elapsed time: 00:00:00.000134
     21:10:42.299577 return      10     f3()
     Return value:.. None
 21:10:42.299627 return       6     f2()

--- a/tests/samples/indentation.py
+++ b/tests/samples/indentation.py
@@ -42,4 +42,5 @@ Source path:... Whatever
     Return value:.. None
 21:10:42.299627 return       6     f2()
 Return value:.. None
+Total elapsed time: 00:00:00.000885
 '''

--- a/tests/samples/recursion.py
+++ b/tests/samples/recursion.py
@@ -18,46 +18,49 @@ def main():
 expected_output = '''
 Source path:... Whatever
 Starting var:.. x = 4
-20:28:17.875295 call         5 def factorial(x):
-20:28:17.875509 line         6     if x <= 1:
-20:28:17.875550 line         8     return mul(x, factorial(x - 1))
+09:31:32.691599 call         5 def factorial(x):
+09:31:32.691722 line         6     if x <= 1:
+09:31:32.691746 line         8     return mul(x, factorial(x - 1))
     Starting var:.. x = 3
-    20:28:17.875624 call         5 def factorial(x):
-    20:28:17.875668 line         6     if x <= 1:
-    20:28:17.875703 line         8     return mul(x, factorial(x - 1))
+    09:31:32.691781 call         5 def factorial(x):
+    09:31:32.691806 line         6     if x <= 1:
+    09:31:32.691823 line         8     return mul(x, factorial(x - 1))
         Starting var:.. x = 2
-        20:28:17.875771 call         5 def factorial(x):
-        20:28:17.875813 line         6     if x <= 1:
-        20:28:17.875849 line         8     return mul(x, factorial(x - 1))
+        09:31:32.691852 call         5 def factorial(x):
+        09:31:32.691875 line         6     if x <= 1:
+        09:31:32.691892 line         8     return mul(x, factorial(x - 1))
             Starting var:.. x = 1
-            20:28:17.875913 call         5 def factorial(x):
-            20:28:17.875953 line         6     if x <= 1:
-            20:28:17.875987 line         7         return 1
-            20:28:17.876021 return       7         return 1
+            09:31:32.691918 call         5 def factorial(x):
+            09:31:32.691941 line         6     if x <= 1:
+            09:31:32.691961 line         7         return 1
+            09:31:32.691978 return       7         return 1
             Return value:.. 1
+            Total elapsed time: 00:00:00.000092
             Starting var:.. a = 2
             Starting var:.. b = 1
-            20:28:17.876111 call        11 def mul(a, b):
-            20:28:17.876151 line        12     return a * b
-            20:28:17.876190 return      12     return a * b
+            09:31:32.692025 call        11 def mul(a, b):
+            09:31:32.692055 line        12     return a * b
+            09:31:32.692075 return      12     return a * b
             Return value:.. 2
-        20:28:17.876235 return       8     return mul(x, factorial(x - 1))
+        09:31:32.692102 return       8     return mul(x, factorial(x - 1))
         Return value:.. 2
+        Total elapsed time: 00:00:00.000283
         Starting var:.. a = 3
         Starting var:.. b = 2
-        20:28:17.876320 call        11 def mul(a, b):
-        20:28:17.876359 line        12     return a * b
-        20:28:17.876397 return      12     return a * b
+        09:31:32.692147 call        11 def mul(a, b):
+        09:31:32.692174 line        12     return a * b
+        09:31:32.692193 return      12     return a * b
         Return value:.. 6
-    20:28:17.876442 return       8     return mul(x, factorial(x - 1))
+    09:31:32.692216 return       8     return mul(x, factorial(x - 1))
     Return value:.. 6
+    Total elapsed time: 00:00:00.000468
     Starting var:.. a = 4
     Starting var:.. b = 6
-    20:28:17.876525 call        11 def mul(a, b):
-    20:28:17.876563 line        12     return a * b
-    20:28:17.876601 return      12     return a * b
+    09:31:32.692259 call        11 def mul(a, b):
+    09:31:32.692285 line        12     return a * b
+    09:31:32.692304 return      12     return a * b
     Return value:.. 24
-20:28:17.876646 return       8     return mul(x, factorial(x - 1))
+09:31:32.692326 return       8     return mul(x, factorial(x - 1))
 Return value:.. 24
-Total elapsed time: 00:00:00.000651
+Total elapsed time: 00:00:00.000760
 '''

--- a/tests/samples/recursion.py
+++ b/tests/samples/recursion.py
@@ -59,4 +59,5 @@ Starting var:.. x = 4
     Return value:.. 24
 20:28:17.876646 return       8     return mul(x, factorial(x - 1))
 Return value:.. 24
+Total elapsed time: 00:00:00.000651
 '''

--- a/tests/test_chinese.py
+++ b/tests/test_chinese.py
@@ -16,7 +16,8 @@ from pysnooper import pycompat
 from pysnooper.variables import needs_parentheses
 from .utils import (assert_output, assert_sample_output, VariableEntry,
                     CallEntry, LineEntry, ReturnEntry, OpcodeEntry,
-                    ReturnValueEntry, ExceptionEntry, SourcePathEntry)
+                    ReturnValueEntry, ExceptionEntry, SourcePathEntry,
+                    ElapsedTimeEntry)
 from . import mini_toolbox
 
 
@@ -44,6 +45,7 @@ def test_chinese():
                 VariableEntry(u'x', (u"'失败'" if pycompat.PY3 else None)),
                 LineEntry(),
                 ReturnEntry(),
-                ReturnValueEntry('7')
+                ReturnValueEntry('7'),
+                ElapsedTimeEntry(),
             ),
         )

--- a/tests/test_multiple_files/test_multiple_files.py
+++ b/tests/test_multiple_files/test_multiple_files.py
@@ -15,7 +15,8 @@ import pysnooper
 from pysnooper.variables import needs_parentheses
 from ..utils import (assert_output, assert_sample_output, VariableEntry,
                     CallEntry, LineEntry, ReturnEntry, OpcodeEntry,
-                    ReturnValueEntry, ExceptionEntry, SourcePathEntry)
+                    ReturnValueEntry, ExceptionEntry, SourcePathEntry,
+                    ElapsedTimeEntry)
 from .. import mini_toolbox
 from .multiple_files import foo
 
@@ -45,6 +46,7 @@ def test_multiple_files():
             LineEntry(),
             ReturnEntry(),
             ReturnValueEntry(),
+            ElapsedTimeEntry(),
         )
     )
 

--- a/tests/test_pysnooper.py
+++ b/tests/test_pysnooper.py
@@ -15,7 +15,8 @@ import pysnooper
 from pysnooper.variables import needs_parentheses
 from .utils import (assert_output, assert_sample_output, VariableEntry,
                     CallEntry, LineEntry, ReturnEntry, OpcodeEntry,
-                    ReturnValueEntry, ExceptionEntry, SourcePathEntry)
+                    ReturnValueEntry, ExceptionEntry, SourcePathEntry,
+                    ElapsedTimeEntry)
 from . import mini_toolbox
 
 
@@ -44,6 +45,7 @@ def test_string_io():
             LineEntry('return y + x'),
             ReturnEntry('return y + x'),
             ReturnValueEntry('15'),
+            ElapsedTimeEntry(),
         )
     )
 
@@ -74,6 +76,7 @@ def test_thread_info():
             LineEntry('return y + x'),
             ReturnEntry('return y + x'),
             ReturnValueEntry('15'),
+            ElapsedTimeEntry(),
         )
     )
 
@@ -125,6 +128,7 @@ def test_multi_thread_info():
                           name="MainThread")),
             ReturnEntry('return y + x'),
             ReturnValueEntry('15'),
+            ElapsedTimeEntry(),
             VariableEntry('foo', value_regex="u?'bubu'"),
             CallEntry('def my_function(foo):',
                       thread_info_regex=thread_info_regex.format(
@@ -142,6 +146,7 @@ def test_multi_thread_info():
                           name="test123")),
             ReturnEntry('return y + x'),
             ReturnValueEntry('15'),
+            ElapsedTimeEntry(),
             VariableEntry('foo', value_regex="u?'bibi'"),
             CallEntry('def my_function(foo):',
                       thread_info_regex=thread_info_regex.format(name='bibi')),
@@ -155,6 +160,7 @@ def test_multi_thread_info():
                       thread_info_regex=thread_info_regex.format(name='bibi')),
             ReturnEntry('return y + x'),
             ReturnValueEntry('15'),
+            ElapsedTimeEntry(),
         )
     )
 
@@ -188,6 +194,7 @@ def test_callable(normalize):
             LineEntry('return y + x'),
             ReturnEntry('return y + x'),
             ReturnValueEntry('15'),
+            ElapsedTimeEntry(),
         ),
         normalize=normalize,
     )
@@ -240,7 +247,8 @@ def test_watch(normalize):
             VariableEntry('len(foo.__dict__["x"] * "abc")', '48'),
             LineEntry(),
             ReturnEntry(),
-            ReturnValueEntry('None')
+            ReturnValueEntry('None'),
+            ElapsedTimeEntry(),
         ),
         normalize=normalize,
     )
@@ -291,7 +299,8 @@ def test_watch_explode(normalize):
             VariableEntry('(lst + [])[3]', '10'),
             VariableEntry('lst + []'),
             ReturnEntry(),
-            ReturnValueEntry('None')
+            ReturnValueEntry('None'),
+            ElapsedTimeEntry(),
         ),
         normalize=normalize,
     )
@@ -342,7 +351,8 @@ def test_variables_classes(normalize):
             VariableEntry('_lst[998]', '998'),
             VariableEntry('_lst[999]', '999'),
             ReturnEntry(),
-            ReturnValueEntry('None')
+            ReturnValueEntry('None'),
+            ElapsedTimeEntry(),
         ),
         normalize=normalize,
     )
@@ -384,7 +394,8 @@ def test_single_watch_no_comma(normalize):
             LineEntry(),
             LineEntry(),
             ReturnEntry(),
-            ReturnValueEntry('None')
+            ReturnValueEntry('None'),
+            ElapsedTimeEntry(),
         ),
         normalize=normalize,
     )
@@ -412,7 +423,8 @@ def test_long_variable(normalize):
             VariableEntry('foo', value_regex=regex),
             LineEntry(),
             ReturnEntry(),
-            ReturnValueEntry(value_regex=regex)
+            ReturnValueEntry(value_regex=regex),
+            ElapsedTimeEntry(),
         ),
         normalize=normalize,
     )
@@ -440,7 +452,8 @@ def test_long_variable_with_custom_max_variable_length(normalize):
             VariableEntry('foo', value_regex=regex),
             LineEntry(),
             ReturnEntry(),
-            ReturnValueEntry(value_regex=regex)
+            ReturnValueEntry(value_regex=regex),
+            ElapsedTimeEntry(),
         ),
         normalize=normalize,
     )
@@ -468,7 +481,8 @@ def test_long_variable_with_infinite_max_variable_length(normalize):
             VariableEntry('foo', value_regex=regex),
             LineEntry(),
             ReturnEntry(),
-            ReturnValueEntry(value_regex=regex)
+            ReturnValueEntry(value_regex=regex),
+            ElapsedTimeEntry(),
         ),
         normalize=normalize,
     )
@@ -498,7 +512,8 @@ def test_repr_exception(normalize):
             LineEntry('bad = Bad()'),
             VariableEntry('bad', value='REPR FAILED'),
             ReturnEntry(),
-            ReturnValueEntry('None')
+            ReturnValueEntry('None'),
+            ElapsedTimeEntry(),
         ),
         normalize=normalize,
     )
@@ -561,6 +576,7 @@ def test_depth(normalize):
             LineEntry(),
             ReturnEntry(),
             ReturnValueEntry('20'),
+            ElapsedTimeEntry(),
         ),
         normalize=normalize,
     )
@@ -600,6 +616,7 @@ def test_method_and_prefix(normalize):
             LineEntry(prefix='ZZZ'),
             ReturnEntry(prefix='ZZZ'),
             ReturnValueEntry(prefix='ZZZ'),
+            ElapsedTimeEntry(prefix='ZZZ'),
         ),
         prefix='ZZZ',
         normalize=normalize,
@@ -634,6 +651,7 @@ def test_file_output(normalize):
                 LineEntry('return y + x'),
                 ReturnEntry('return y + x'),
                 ReturnValueEntry('15'),
+                ElapsedTimeEntry(),
             ),
             normalize=normalize,
         )
@@ -679,6 +697,7 @@ def test_confusing_decorator_lines(normalize):
             # back in my_function
             ReturnEntry(),
             ReturnValueEntry('15'),
+            ElapsedTimeEntry(),
         ),
         normalize=normalize,
     )
@@ -700,6 +719,7 @@ def test_lambda(normalize):
             LineEntry(source_regex='^my_function = pysnooper.*'),
             ReturnEntry(source_regex='^my_function = pysnooper.*'),
             ReturnValueEntry('49'),
+            ElapsedTimeEntry(),
         ),
         normalize=normalize,
     )
@@ -734,6 +754,7 @@ def test_unavailable_source():
                 LineEntry('SOURCE IS UNAVAILABLE'),
                 ReturnEntry('SOURCE IS UNAVAILABLE'),
                 ReturnValueEntry('7'),
+                ElapsedTimeEntry(),
             )
         )
 
@@ -767,6 +788,7 @@ def test_no_overwrite_by_default():
                 LineEntry('return y + x'),
                 ReturnEntry('return y + x'),
                 ReturnValueEntry('15'),
+                ElapsedTimeEntry(),
             )
         )
 
@@ -800,6 +822,7 @@ def test_overwrite():
                 LineEntry('return y + x'),
                 ReturnEntry('return y + x'),
                 ReturnValueEntry('15'),
+                ElapsedTimeEntry(),
 
                 VariableEntry('foo', value_regex="u?'baba'"),
                 CallEntry('def my_function(foo):'),
@@ -810,6 +833,7 @@ def test_overwrite():
                 LineEntry('return y + x'),
                 ReturnEntry('return y + x'),
                 ReturnValueEntry('15'),
+                ElapsedTimeEntry(),
             )
         )
 
@@ -914,6 +938,7 @@ def test_with_block(normalize):
             LineEntry('qux()'),
             ReturnEntry('qux()'),
             ReturnValueEntry('None'),
+            ElapsedTimeEntry(),
 
             # In with in recursive call
             LineEntry('bar2(x)'),
@@ -925,9 +950,11 @@ def test_with_block(normalize):
             LineEntry('qux()'),
             ReturnEntry('qux()'),
             ReturnValueEntry('None'),
+            ElapsedTimeEntry(),
 
             # In with in recursive call
             LineEntry('qux()'),
+            ElapsedTimeEntry(),
 
             # Call to bar3 from after with
             VariableEntry('_x', '9'),
@@ -936,6 +963,7 @@ def test_with_block(normalize):
             LineEntry('qux()'),
             ReturnEntry('qux()'),
             ReturnValueEntry('None'),
+            ElapsedTimeEntry(),
 
             # -- Similar to previous few sections,
             # -- but from first call to foo
@@ -950,9 +978,11 @@ def test_with_block(normalize):
             LineEntry('qux()'),
             ReturnEntry('qux()'),
             ReturnValueEntry('None'),
+            ElapsedTimeEntry(),
 
             # In with in first call
             LineEntry('qux()'),
+            ElapsedTimeEntry(),
 
             # Call to bar3 from after with
             VariableEntry('_x', '9'),
@@ -961,6 +991,7 @@ def test_with_block(normalize):
             LineEntry('qux()'),
             ReturnEntry('qux()'),
             ReturnValueEntry('None'),
+            ElapsedTimeEntry(),
         ),
         normalize=normalize,
     )
@@ -1020,6 +1051,7 @@ def test_with_block_depth(normalize):
             LineEntry(),
             ReturnEntry(),
             ReturnValueEntry('20'),
+            ElapsedTimeEntry(),
         ),
         normalize=normalize,
     )
@@ -1086,6 +1118,7 @@ def test_cellvars(normalize):
             ReturnValueEntry(),
             ReturnEntry(),
             ReturnValueEntry(),
+            ElapsedTimeEntry(),
         ),
         normalize=normalize,
     )
@@ -1133,6 +1166,7 @@ def test_var_order(normalize):
             VariableEntry("seven", "7"),
             ReturnEntry(),
             ReturnValueEntry(),
+            ElapsedTimeEntry(),
         ),
         normalize=normalize,
     )
@@ -1207,6 +1241,7 @@ def test_generator():
             LineEntry(),
             ReturnEntry(),
             ReturnValueEntry('0'),
+            ElapsedTimeEntry(),
 
             # Pause and resume:
 
@@ -1223,6 +1258,7 @@ def test_generator():
             LineEntry(),
             ReturnEntry(),
             ReturnValueEntry('2'),
+            ElapsedTimeEntry(),
 
             # Pause and resume:
 
@@ -1238,7 +1274,7 @@ def test_generator():
             LineEntry(),
             ReturnEntry(),
             ReturnValueEntry(None),
-
+            ElapsedTimeEntry(),
         )
     )
 
@@ -1285,6 +1321,7 @@ def test_custom_repr(normalize):
             LineEntry(),
             ReturnEntry(),
             ReturnValueEntry('49995000'),
+            ElapsedTimeEntry(),
         ),
         normalize=normalize,
     )
@@ -1313,6 +1350,7 @@ def test_custom_repr_single(normalize):
             LineEntry(),
             ReturnEntry(),
             ReturnValueEntry('7'),
+            ElapsedTimeEntry(),
         ),
         normalize=normalize,
     )
@@ -1363,6 +1401,7 @@ def test_class(normalize):
             LineEntry('self.x = 7'),
             ReturnEntry('self.x = 7'),
             ReturnValueEntry('None'),
+            ElapsedTimeEntry(),
             VariableEntry('self', value_regex="u?.+MyClass object"),
             VariableEntry('foo', value_regex="u?'baba'"),
             CallEntry('def my_method(self, foo):'),
@@ -1371,6 +1410,7 @@ def test_class(normalize):
             LineEntry('return y + self.x'),
             ReturnEntry('return y + self.x'),
             ReturnValueEntry('15'),
+            ElapsedTimeEntry(),
         ),
         normalize=normalize,
     )
@@ -1409,6 +1449,7 @@ def test_class_with_decorated_method(normalize):
             LineEntry('self.x = 7'),
             ReturnEntry('self.x = 7'),
             ReturnValueEntry('None'),
+            ElapsedTimeEntry(),
             VariableEntry('args', value_regex=r"\(<.+>, 'baba'\)"),
             VariableEntry('kwargs', value_regex=r"\{\}"),
             VariableEntry('function', value_regex="u?.+my_method"),
@@ -1418,6 +1459,7 @@ def test_class_with_decorated_method(normalize):
             LineEntry('return result'),
             ReturnEntry('return result'),
             ReturnValueEntry('15'),
+            ElapsedTimeEntry(),
         ),
         normalize=normalize,
     )
@@ -1457,6 +1499,7 @@ def test_class_with_decorated_method_and_snoop_applied_to_method(normalize):
             LineEntry('self.x = 7'),
             ReturnEntry('self.x = 7'),
             ReturnValueEntry('None'),
+            ElapsedTimeEntry(),
             VariableEntry('args', value_regex=r"u?\(<.+>, 'baba'\)"),
             VariableEntry('kwargs', value_regex=r"u?\{\}"),
             VariableEntry('function', value_regex="u?.*my_method"),
@@ -1475,6 +1518,7 @@ def test_class_with_decorated_method_and_snoop_applied_to_method(normalize):
             LineEntry('return result'),
             ReturnEntry('return result'),
             ReturnValueEntry('15'),
+            ElapsedTimeEntry(),
         ),
         normalize=normalize,
     )
@@ -1531,6 +1575,7 @@ def test_class_with_property(normalize):
             LineEntry('self._x = 0'),
             ReturnEntry('self._x = 0'),
             ReturnValueEntry('None'),
+            ElapsedTimeEntry(),
 
             # Called from getter
             VariableEntry('self', value_regex="u?.*MyClass object"),
@@ -1538,6 +1583,7 @@ def test_class_with_property(normalize):
             LineEntry('pass'),
             ReturnEntry('pass'),
             ReturnValueEntry('None'),
+            ElapsedTimeEntry(),
 
             # Called from setter
             VariableEntry('self', value_regex="u?.*MyClass object"),
@@ -1545,6 +1591,7 @@ def test_class_with_property(normalize):
             LineEntry('pass'),
             ReturnEntry('pass'),
             ReturnValueEntry('None'),
+            ElapsedTimeEntry(),
 
             # Called from deleter
             VariableEntry('self', value_regex="u?.*MyClass object"),
@@ -1552,6 +1599,7 @@ def test_class_with_property(normalize):
             LineEntry('pass'),
             ReturnEntry('pass'),
             ReturnValueEntry('None'),
+            ElapsedTimeEntry(),
         ),
         normalize=normalize,
     )
@@ -1589,6 +1637,7 @@ def test_snooping_on_class_does_not_cause_base_class_to_be_snooped(normalize):
             LineEntry('self.method_on_base_class()'),
             ReturnEntry('self.method_on_base_class()'),
             ReturnValueEntry('None'),
+            ElapsedTimeEntry(),
         ),
         normalize=normalize,
     )
@@ -1625,6 +1674,7 @@ def test_normalize():
                 LineEntry('return res'),
                 ReturnEntry('return res'),
                 ReturnValueEntry('41'),
+                ElapsedTimeEntry(),
             )
     )
 
@@ -1661,6 +1711,7 @@ def test_normalize_prefix():
                 LineEntry('return res', prefix=_prefix),
                 ReturnEntry('return res', prefix=_prefix),
                 ReturnValueEntry('41', prefix=_prefix),
+                ElapsedTimeEntry(prefix=_prefix),
             )
     )
 

--- a/tests/test_pysnooper.py
+++ b/tests/test_pysnooper.py
@@ -4,6 +4,7 @@
 import io
 import textwrap
 import threading
+import time
 import types
 import os
 import sys
@@ -51,32 +52,132 @@ def test_string_io():
 
 
 def test_elapsed_time():
-    string_io = io.StringIO()
+    snoop = pysnooper.snoop(elapsed_time=True)
 
-    @pysnooper.snoop(string_io, elapsed_time=True)
-    def my_function(foo):
-        x = 7
-        y = 8
-        return y + x
+    def foo(x):
+        if x == 0:
+            bar1(x)
+            qux()
+            return
 
-    result = my_function('baba')
-    assert result == 15
-    output = string_io.getvalue()
+        with snoop:
+            # There should be line entries for these three lines,
+            # no line entries for anything else in this function,
+            # but calls to all bar functions should be traced
+            foo(x - 1)
+            bar2(x)
+            qux()
+        int(4)
+        bar3(9)
+        return x
+
+    @snoop
+    def bar1(_x):
+        qux()
+
+    @snoop
+    def bar2(_x):
+        qux()
+
+    @snoop
+    def bar3(_x):
+        qux()
+
+    def qux():
+        time.sleep(0.1)
+        return 9  # not traced, mustn't show up
+
+    with mini_toolbox.OutputCapturer(stdout=False,
+                                     stderr=True) as output_capturer:
+        result = foo(2)
+    assert result == 2
+    output = output_capturer.string_io.getvalue()
     assert_output(
         output,
         (
+            # In first with
             SourcePathEntry(),
-            VariableEntry('foo', value_regex="u?'baba'"),
-            CallEntry('def my_function(foo):'),
-            LineEntry('x = 7'),
-            VariableEntry('x', '7'),
-            LineEntry('y = 8'),
-            VariableEntry('y', '8'),
-            LineEntry('return y + x'),
-            ReturnEntry('return y + x'),
-            ReturnValueEntry('15'),
-            ElapsedTimeEntry(),
-        )
+            VariableEntry('x', '2'),
+            VariableEntry('bar1'),
+            VariableEntry('bar2'),
+            VariableEntry('bar3'),
+            VariableEntry('foo'),
+            VariableEntry('qux'),
+            VariableEntry('snoop'),
+            LineEntry('foo(x - 1)'),
+
+            # In with in recursive call
+            VariableEntry('x', '1'),
+            VariableEntry('bar1'),
+            VariableEntry('bar2'),
+            VariableEntry('bar3'),
+            VariableEntry('foo'),
+            VariableEntry('qux'),
+            VariableEntry('snoop'),
+            LineEntry('foo(x - 1)'),
+
+            # Call to bar1 from if block outside with
+            VariableEntry('_x', '0'),
+            VariableEntry('qux'),
+            CallEntry('def bar1(_x):'),
+            LineEntry('qux()'),
+            ReturnEntry('qux()'),
+            ReturnValueEntry('None'),
+            ElapsedTimeEntry(0.1),
+
+            # In with in recursive call
+            LineEntry('bar2(x)'),
+
+            # Call to bar2 from within with
+            VariableEntry('_x', '1'),
+            VariableEntry('qux'),
+            CallEntry('def bar2(_x):'),
+            LineEntry('qux()'),
+            ReturnEntry('qux()'),
+            ReturnValueEntry('None'),
+            ElapsedTimeEntry(0.1),
+
+            # In with in recursive call
+            LineEntry('qux()'),
+            ElapsedTimeEntry(0.4),
+
+            # Call to bar3 from after with
+            VariableEntry('_x', '9'),
+            VariableEntry('qux'),
+            CallEntry('def bar3(_x):'),
+            LineEntry('qux()'),
+            ReturnEntry('qux()'),
+            ReturnValueEntry('None'),
+            ElapsedTimeEntry(0.1),
+
+            # -- Similar to previous few sections,
+            # -- but from first call to foo
+
+            # In with in first call
+            LineEntry('bar2(x)'),
+
+            # Call to bar2 from within with
+            VariableEntry('_x', '2'),
+            VariableEntry('qux'),
+            CallEntry('def bar2(_x):'),
+            LineEntry('qux()'),
+            ReturnEntry('qux()'),
+            ReturnValueEntry('None'),
+            ElapsedTimeEntry(0.1),
+
+            # In with in first call
+            LineEntry('qux()'),
+            ElapsedTimeEntry(0.7),
+
+            # Call to bar3 from after with
+            VariableEntry('_x', '9'),
+            VariableEntry('qux'),
+            CallEntry('def bar3(_x):'),
+            LineEntry('qux()'),
+            ReturnEntry('qux()'),
+            ReturnValueEntry('None'),
+            ElapsedTimeEntry(0.1),
+        ),
     )
 
 

--- a/tests/test_pysnooper.py
+++ b/tests/test_pysnooper.py
@@ -50,6 +50,36 @@ def test_string_io():
     )
 
 
+def test_relative_time():
+    string_io = io.StringIO()
+
+    @pysnooper.snoop(string_io, relative_time=True)
+    def my_function(foo):
+        x = 7
+        y = 8
+        return y + x
+
+    result = my_function('baba')
+    assert result == 15
+    output = string_io.getvalue()
+    assert_output(
+        output,
+        (
+            SourcePathEntry(),
+            VariableEntry('foo', value_regex="u?'baba'"),
+            CallEntry('def my_function(foo):'),
+            LineEntry('x = 7'),
+            VariableEntry('x', '7'),
+            LineEntry('y = 8'),
+            VariableEntry('y', '8'),
+            LineEntry('return y + x'),
+            ReturnEntry('return y + x'),
+            ReturnValueEntry('15'),
+            ElapsedTimeEntry(),
+        )
+    )
+
+
 def test_thread_info():
 
     @pysnooper.snoop(thread_info=True)

--- a/tests/test_pysnooper.py
+++ b/tests/test_pysnooper.py
@@ -50,10 +50,10 @@ def test_string_io():
     )
 
 
-def test_relative_time():
+def test_elapsed_time():
     string_io = io.StringIO()
 
-    @pysnooper.snoop(string_io, relative_time=True)
+    @pysnooper.snoop(string_io, elapsed_time=True)
     def my_function(foo):
         x = 7
         y = 8

--- a/tests/test_pysnooper.py
+++ b/tests/test_pysnooper.py
@@ -1544,6 +1544,7 @@ def test_class_with_decorated_method_and_snoop_applied_to_method(normalize):
             LineEntry('return y + self.x'),
             ReturnEntry('return y + self.x'),
             ReturnValueEntry('15'),
+            ElapsedTimeEntry(),
             VariableEntry('result', '15'),
             LineEntry('return result'),
             ReturnEntry('return result'),

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -221,8 +221,13 @@ class SourcePathEntry(_BaseValueEntry):
 
 
 class ElapsedTimeEntry(_BasePrintEntry):
-    def __init__(self, prefix=''):
+
+    def __init__(self, elapsed_time_value=None,
+                 tolerance=0.05,
+                 prefix=''):
         _BasePrintEntry.__init__(self, prefix=prefix)
+        self.elapsed_time_value = elapsed_time_value
+        self.tolerance = tolerance
 
     _preamble_pattern = re.compile(
         r"""^Total elapsed time$"""
@@ -232,7 +237,13 @@ class ElapsedTimeEntry(_BasePrintEntry):
         return bool(self._preamble_pattern.match(preamble))
 
     def _check_content(self, content):
-        return True
+        if self.elapsed_time_value:
+            time = pysnooper.pycompat.time_fromisoformat(content)
+            sec = (time.hour * 60 + time.minute) * 60 + time.second + \
+                time.microsecond * (10 ** -6)
+            return abs(sec - self.elapsed_time_value) <= self.tolerance
+        else:
+            return True
 
 
 class _BaseEventEntry(_BaseEntry):


### PR DESCRIPTION
Thank you for your awesome debug tool!

This PR added a printing total elapsed time and elapsed_time format option.
The test code is as follows.

```
import argparse
import time

import pysnooper


def test1(elapsed_time=False):
    with pysnooper.snoop(elapsed_time=elapsed_time):
        time.sleep(1.0)


def test2(elapsed_time=False):
    a = 1
    b = 2
    c = 3
    with pysnooper.snoop(elapsed_time=elapsed_time):
        tmp = a + b
        tmp2 = a - b


test1(elapsed_time=False)
print()
test1(elapsed_time=True)
print()
test2(elapsed_time=False)
print()
test2(elapsed_time=True)
```
The result is as follows.
```
Source path:... <ipython-input-14-f06356abdfce>
New var:....... elapsed_time = False
22:14:11.952148 line         9         time.sleep(1.0)
Total elapsed time: 00:00:01.002691

Source path:... <ipython-input-14-f06356abdfce>
New var:....... elapsed_time = True
00:00:00.000007 line         9         time.sleep(1.0)
Total elapsed time: 00:00:01.003509

Source path:... <ipython-input-14-f06356abdfce>
New var:....... elapsed_time = False
New var:....... a = 1
New var:....... b = 2
New var:....... c = 3
22:14:13.959043 line        17         tmp = a + b
New var:....... tmp = 3
22:14:13.959235 line        18         tmp2 = a - b
Total elapsed time: 00:00:00.000334

Source path:... <ipython-input-14-f06356abdfce>
New var:....... elapsed_time = True
New var:....... a = 1
New var:....... b = 2
New var:....... c = 3
00:00:00.000011 line        17         tmp = a + b
New var:....... tmp = 3
00:00:00.000295 line        18         tmp2 = a - b
Total elapsed time: 00:00:00.000409
```