### PR TITLE
Add Memory address information to debug print

### DIFF
--- a/pysnooper/variables.py
+++ b/pysnooper/variables.py
@@ -57,7 +57,10 @@ class BaseVariable(pycompat.ABC):
 
 class CommonVariable(BaseVariable):
     def _items(self, main_value, normalize=False):
-        result = [(self.source, utils.get_shortish_repr(main_value, normalize=normalize))]
+        result = [(self.source,
+                   VariableInfo(utils.get_shortish_repr(
+                       main_value, normalize=normalize),
+                                id(main_value)))]
         for key in self._safe_keys(main_value):
             try:
                 if key in self.exclude:
@@ -67,7 +70,7 @@ class CommonVariable(BaseVariable):
                 continue
             result.append((
                 '{}{}'.format(self.unambiguous_source, self._format_key(key)),
-                utils.get_shortish_repr(value)
+                VariableInfo(utils.get_shortish_repr(value), id(value))
             ))
         return result
 

--- a/pysnooper/variables.py
+++ b/pysnooper/variables.py
@@ -1,4 +1,5 @@
 import itertools
+from collections import namedtuple
 import abc
 try:
     from collections.abc import Mapping, Sequence
@@ -15,6 +16,10 @@ def needs_parentheses(source):
         return compile(s, '<variable>', 'eval').co_code
 
     return code('{}.x'.format(source)) != code('({}).x'.format(source))
+
+
+VariableInfo = namedtuple('VariableInfo',
+                          ('value_repr', 'memory_address'))
 
 
 class BaseVariable(pycompat.ABC):

--- a/tests/samples/recursion.py
+++ b/tests/samples/recursion.py
@@ -17,42 +17,42 @@ def main():
 
 expected_output = '''
 Source path:... Whatever
-Starting var:.. x = 4
+Starting var:.. x = 4 @ Wherever
 20:28:17.875295 call         5 def factorial(x):
 20:28:17.875509 line         6     if x <= 1:
 20:28:17.875550 line         8     return mul(x, factorial(x - 1))
-    Starting var:.. x = 3
+    Starting var:.. x = 3 @ Wherever
     20:28:17.875624 call         5 def factorial(x):
     20:28:17.875668 line         6     if x <= 1:
     20:28:17.875703 line         8     return mul(x, factorial(x - 1))
-        Starting var:.. x = 2
+        Starting var:.. x = 2 @ Wherever
         20:28:17.875771 call         5 def factorial(x):
         20:28:17.875813 line         6     if x <= 1:
         20:28:17.875849 line         8     return mul(x, factorial(x - 1))
-            Starting var:.. x = 1
+            Starting var:.. x = 1 @ Wherever
             20:28:17.875913 call         5 def factorial(x):
             20:28:17.875953 line         6     if x <= 1:
             20:28:17.875987 line         7         return 1
             20:28:17.876021 return       7         return 1
             Return value:.. 1
-            Starting var:.. a = 2
-            Starting var:.. b = 1
+            Starting var:.. a = 2 @ Wherever
+            Starting var:.. b = 1 @ Wherever
             20:28:17.876111 call        11 def mul(a, b):
             20:28:17.876151 line        12     return a * b
             20:28:17.876190 return      12     return a * b
             Return value:.. 2
         20:28:17.876235 return       8     return mul(x, factorial(x - 1))
         Return value:.. 2
-        Starting var:.. a = 3
-        Starting var:.. b = 2
+        Starting var:.. a = 3 @ Wherever
+        Starting var:.. b = 2 @ Wherever
         20:28:17.876320 call        11 def mul(a, b):
         20:28:17.876359 line        12     return a * b
         20:28:17.876397 return      12     return a * b
         Return value:.. 6
     20:28:17.876442 return       8     return mul(x, factorial(x - 1))
     Return value:.. 6
-    Starting var:.. a = 4
-    Starting var:.. b = 6
+    Starting var:.. a = 4 @ Wherever
+    Starting var:.. b = 6 @ Wherever
     20:28:17.876525 call        11 def mul(a, b):
     20:28:17.876563 line        12     return a * b
     20:28:17.876601 return      12     return a * b

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -107,14 +107,14 @@ class VariableEntry(_BaseValueEntry):
         return self._check_stage(stage)
 
     _content_pattern = re.compile(
-        r"""^(?P<name>.+?) = (?P<value>.+)$"""
+        r"""^(?P<name>.+?) = (?P<value>.+) @ 0x(?P<address>[\da-f]+)$"""
     )
 
     def _check_content(self, content):
         match = self._content_pattern.match(content)
         if not match:
             return False
-        name, value = match.groups()
+        name, value, _ = match.groups()
         return self._check_name(name) and self._check_value(value)
 
     def _check_name(self, name):
@@ -333,8 +333,13 @@ def assert_sample_output(module):
             out,
             flags=re.MULTILINE
         )
+        out = re.sub(
+            r'^(?P<indent>(?: {4})*)'
+            r'(?P<stage>(New|Modified|Starting) var:.+) '
+            r'(?P<name>.+?) = (?P<value>.+) @ 0x(?P<address>[\da-f]+)$',
+            r'\1\2 \4 = \5 @ Wherever', out, flags=re.MULTILINE
+        )
         return out
-
 
     output = output_capturer.string_io.getvalue()
 


### PR DESCRIPTION
This PR adds debug prints of variables' memory addresses.
The following is sample code and output.

```
In [1]: import pysnooper
   ...:
   ...:
   ...: def sample_a():
   ...:     with pysnooper.snoop():
   ...:         a = 5
   ...:         print(hex(id(a)))
   ...:         b = 7
   ...:         print(hex(id(b)))
   ...:         c = a * b
   ...:         print(hex(id(c)))
   ...:
   ...:
   ...: sample_a()
   ...:
Source path:... <ipython-input-1-aa3d4b446d39>
21:09:17.797662 line         6         a = 5
New var:....... a = 5 @ 0x107306500
21:09:17.797763 line         7         print(hex(id(a)))
0x107306500
21:09:17.797810 line         8         b = 7
New var:....... b = 7 @ 0x107306540
21:09:17.797839 line         9         print(hex(id(b)))
0x107306540
21:09:17.797878 line        10         c = a * b
New var:....... c = 35 @ 0x1073068c0
21:09:17.797906 line        11         print(hex(id(c)))
0x1073068c0
```


