### PR TITLE
fix #195

### DIFF
--- a/pysnooper/tracer.py
+++ b/pysnooper/tracer.py
@@ -293,6 +293,7 @@ class Tracer:
     def __enter__(self):
         if DISABLED:
             return
+        thread_global.__dict__.setdefault('depth', -1)
         calling_frame = inspect.currentframe().f_back
         if not self._is_internal_frame(calling_frame):
             calling_frame.f_trace = self.trace
@@ -362,7 +363,6 @@ class Tracer:
                 else:
                     return None
 
-        thread_global.__dict__.setdefault('depth', -1)
         if event == 'call':
             thread_global.depth += 1
         indent = ' ' * 4 * thread_global.depth

--- a/tests/test_pysnooper.py
+++ b/tests/test_pysnooper.py
@@ -1894,5 +1894,10 @@ def test_exception():
     )
 
 
+def test_exception_on_entry():
+    @pysnooper.snoop()
+    def f(x):
+        pass
 
-
+    with pytest.raises(TypeError):
+        f()


### PR DESCRIPTION
Fix '_thread._local' object has no attribute 'depth' raised by snooper if there's exception upon calling snooped func by initializing thread_global dict with depth when entering the trace() func