### PR TITLE
Add support for Ansible zipped source files

### DIFF
--- a/pysnooper/tracer.py
+++ b/pysnooper/tracer.py
@@ -20,6 +20,7 @@ if pycompat.PY2:
 
 
 ipython_filename_pattern = re.compile('^<ipython-input-([0-9]+)-.*>$')
+ansible_filename_pattern = re.compile('^(/.+zip)/(ansible/modules/.+)$')
 
 
 def get_local_reprs(frame, watch=(), custom_repr=(), max_length=None, normalize=False):
@@ -67,6 +68,7 @@ def get_path_and_source_from_frame(frame):
             source = source.splitlines()
     if source is None:
         ipython_filename_match = ipython_filename_pattern.match(file_name)
+        ansible_filename_match = ansible_filename_pattern.match(file_name)
         if ipython_filename_match:
             entry_number = int(ipython_filename_match.group(1))
             try:
@@ -75,6 +77,13 @@ def get_path_and_source_from_frame(frame):
                 ((_, _, source_chunk),) = ipython_shell.history_manager. \
                                   get_range(0, entry_number, entry_number + 1)
                 source = source_chunk.splitlines()
+            except Exception:
+                pass
+        elif ansible_filename_match:
+            try:
+                import zipfile
+                archive_file = zipfile.ZipFile(ansible_filename_match.group(1), 'r')
+                source = archive_file.read(ansible_filename_match.group(2)).splitlines()
             except Exception:
                 pass
         else:

--- a/pysnooper/tracer.py
+++ b/pysnooper/tracer.py
@@ -20,7 +20,7 @@ if pycompat.PY2:
 
 
 ipython_filename_pattern = re.compile('^<ipython-input-([0-9]+)-.*>$')
-ansible_filename_pattern = re.compile(r'^(/.+\.zip)/(ansible/modules/.+\.py)$')
+ansible_filename_pattern = re.compile(r'^(.+\.zip)[/|\\](ansible[/|\\]modules[/|\\].+\.py)$')
 
 
 def get_local_reprs(frame, watch=(), custom_repr=(), max_length=None, normalize=False):
@@ -83,7 +83,7 @@ def get_path_and_source_from_frame(frame):
             try:
                 import zipfile
                 archive_file = zipfile.ZipFile(ansible_filename_match.group(1), 'r')
-                source = archive_file.read(ansible_filename_match.group(2)).splitlines()
+                source = archive_file.read(ansible_filename_match.group(2).replace('\\', '/')).splitlines()
             except Exception:
                 pass
         else:

--- a/pysnooper/tracer.py
+++ b/pysnooper/tracer.py
@@ -20,7 +20,7 @@ if pycompat.PY2:
 
 
 ipython_filename_pattern = re.compile('^<ipython-input-([0-9]+)-.*>$')
-ansible_filename_pattern = re.compile('^(/.+zip)/(ansible/modules/.+)$')
+ansible_filename_pattern = re.compile(r'^(/.+\.zip)/(ansible/modules/.+\.py)$')
 
 
 def get_local_reprs(frame, watch=(), custom_repr=(), max_length=None, normalize=False):

--- a/tests/test_pysnooper.py
+++ b/tests/test_pysnooper.py
@@ -8,6 +8,8 @@ import time
 import types
 import os
 import sys
+import zipfile
+import importlib
 
 from pysnooper.utils import truncate
 import pytest
@@ -1914,3 +1916,147 @@ def test_exception_on_entry():
 
     with pytest.raises(TypeError):
         f()
+
+
+def test_valid_zipfile():
+    with mini_toolbox.create_temp_folder(prefix='pysnooper') as folder, \
+                                    mini_toolbox.TempSysPathAdder(str(folder)):
+        module_name = 'my_valid_zip_module'
+        zip_name = 'valid.zip'
+        zip_base_path = 'ansible/modules'
+        python_file_path = folder / ('%s/%s/%s.py' % (zip_name, zip_base_path, module_name))
+        os.makedirs(folder / ('%s/%s' % (zip_name, zip_base_path)))
+        sys.path.insert(0, str(folder / (zip_name)))
+        content = textwrap.dedent(u'''
+            import pysnooper
+            @pysnooper.snoop(color=False)
+            def f(x):
+                return x
+        ''')
+        with python_file_path.open('w') as python_file:
+            python_file.write(content)
+
+        module = importlib.import_module('%s.%s' % ('.'.join(zip_base_path.split('/')), module_name))
+
+        with zipfile.ZipFile(folder / 'foo_bar.zip', 'w') as myZipFile:
+            myZipFile.write(folder.joinpath('%s/%s/%s.py' % (zip_name, zip_base_path, module_name)), '%s/%s.py' % (zip_base_path, module_name,), zipfile.ZIP_DEFLATED)
+
+        python_file_path.unlink()
+        os.rename(folder.joinpath(zip_name), folder.joinpath('%s.delete' % (zip_name)),)
+        os.rename(folder / 'foo_bar.zip', folder.joinpath(zip_name),)
+
+        with mini_toolbox.OutputCapturer(stdout=False,
+                                         stderr=True) as output_capturer:
+            result = getattr(module, 'f')(7)
+        assert result == 7
+        output = output_capturer.output
+
+        assert_output(
+            output,
+            (
+                SourcePathEntry(),
+                VariableEntry(stage='starting'),
+                CallEntry('def f(x):'),
+                LineEntry('return x'),
+                ReturnEntry('return x'),
+                ReturnValueEntry('7'),
+                ElapsedTimeEntry(),
+            )
+        )
+
+
+def test_invalid_zipfile():
+    with mini_toolbox.create_temp_folder(prefix='pysnooper') as folder, \
+                                    mini_toolbox.TempSysPathAdder(str(folder)):
+        module_name = 'my_invalid_zip_module'
+        zip_name = 'invalid.zip'
+        zip_base_path = 'invalid/modules/path'
+        python_file_path = folder / ('%s/%s/%s.py' % (zip_name, zip_base_path, module_name))
+        os.makedirs(folder / ('%s/%s' % (zip_name, zip_base_path)))
+        sys.path.insert(0, str(folder / (zip_name)))
+        content = textwrap.dedent(u'''
+            import pysnooper
+            @pysnooper.snoop(color=False)
+            def f(x):
+                return x
+        ''')
+        with python_file_path.open('w') as python_file:
+            python_file.write(content)
+
+        module = importlib.import_module('%s.%s' % ('.'.join(zip_base_path.split('/')), module_name))
+
+        with zipfile.ZipFile(folder / 'foo_bar.zip', 'w') as myZipFile:
+            myZipFile.write(folder.joinpath('%s/%s/%s.py' % (zip_name, zip_base_path, module_name)), '%s/%s.py' % (zip_base_path, module_name,), zipfile.ZIP_DEFLATED)
+
+        python_file_path.unlink()
+        os.rename(folder.joinpath(zip_name), folder.joinpath('%s.delete' % (zip_name)),)
+        os.rename(folder / 'foo_bar.zip', folder.joinpath(zip_name),)
+
+        with mini_toolbox.OutputCapturer(stdout=False,
+                                         stderr=True) as output_capturer:
+            result = getattr(module, 'f')(7)
+        assert result == 7
+        output = output_capturer.output
+
+        assert_output(
+            output,
+            (
+                SourcePathEntry(),
+                VariableEntry(stage='starting'),
+                CallEntry('SOURCE IS UNAVAILABLE'),
+                LineEntry('SOURCE IS UNAVAILABLE'),
+                ReturnEntry('SOURCE IS UNAVAILABLE'),
+                ReturnValueEntry('7'),
+                ElapsedTimeEntry(),
+            )
+        )
+
+
+def test_valid_damaged_zipfile():
+    with mini_toolbox.create_temp_folder(prefix='pysnooper') as folder, \
+                                    mini_toolbox.TempSysPathAdder(str(folder)):
+        module_name = 'my_damaged_module'
+        zip_name = 'damaged.zip'
+        zip_base_path = 'ansible/modules'
+        python_file_path = folder / ('%s/%s/%s.py' % (zip_name, zip_base_path, module_name))
+        os.makedirs(folder / ('%s/%s' % (zip_name, zip_base_path)))
+        sys.path.insert(0, str(folder / (zip_name)))
+        content = textwrap.dedent(u'''
+            import pysnooper
+            @pysnooper.snoop(color=False)
+            def f(x):
+                return x
+        ''')
+        with python_file_path.open('w') as python_file:
+            python_file.write(content)
+
+        module = importlib.import_module('%s.%s' % ('.'.join(zip_base_path.split('/')), module_name))
+
+        python_file_path.unlink()
+        os.rename(folder.joinpath(zip_name), folder.joinpath('%s.delete' % (zip_name)),)
+
+        content_damaged_zip = textwrap.dedent(u'''
+            I am not a zip file
+        ''')
+
+        with folder.joinpath(zip_name).open('w') as damaged_zip_file:
+            damaged_zip_file.write(content_damaged_zip)
+
+        with mini_toolbox.OutputCapturer(stdout=False,
+                                         stderr=True) as output_capturer:
+            result = getattr(module, 'f')(7)
+        assert result == 7
+        output = output_capturer.output
+
+        assert_output(
+            output,
+            (
+                SourcePathEntry(),
+                VariableEntry(stage='starting'),
+                CallEntry('SOURCE IS UNAVAILABLE'),
+                LineEntry('SOURCE IS UNAVAILABLE'),
+                ReturnEntry('SOURCE IS UNAVAILABLE'),
+                ReturnValueEntry('7'),
+                ElapsedTimeEntry(),
+            )
+        )

--- a/tests/test_pysnooper.py
+++ b/tests/test_pysnooper.py
@@ -1947,7 +1947,7 @@ def test_valid_zipfile():
             python_file_path.unlink()
             folder.joinpath(zip_name).rename(folder.joinpath('%s.delete' % (zip_name)))
             folder.joinpath('foo_bar.zip').rename(folder.joinpath(zip_name))
-            breakpoint()
+
             with mini_toolbox.OutputCapturer(stdout=False,
                                              stderr=True) as output_capturer:
                 result = getattr(module, 'f')(7)
@@ -1999,7 +1999,7 @@ def test_invalid_zipfile():
             python_file_path.unlink()
             folder.joinpath(zip_name).rename(folder.joinpath('%s.delete' % (zip_name)))
             folder.joinpath('foo_bar.zip').rename(folder.joinpath(zip_name))
-            breakpoint()
+
             with mini_toolbox.OutputCapturer(stdout=False,
                                          stderr=True) as output_capturer:
                 result = getattr(module, 'f')(7)
@@ -2047,7 +2047,7 @@ def test_valid_damaged_zipfile():
             folder.joinpath(zip_name).rename(folder.joinpath('%s.delete' % (zip_name)))
 
             folder.joinpath(zip_name).write_text('I am not a zip file')
-            breakpoint()
+
             with mini_toolbox.OutputCapturer(stdout=False,
                                          stderr=True) as output_capturer:
                 result = getattr(module, 'f')(7)

--- a/tests/test_pysnooper.py
+++ b/tests/test_pysnooper.py
@@ -1924,45 +1924,50 @@ def test_valid_zipfile():
         module_name = 'my_valid_zip_module'
         zip_name = 'valid.zip'
         zip_base_path = 'ansible/modules'
-        python_file_path = folder / ('%s/%s/%s.py' % (zip_name, zip_base_path, module_name))
-        os.makedirs(folder / ('%s/%s' % (zip_name, zip_base_path)))
-        sys.path.insert(0, str(folder / (zip_name)))
-        content = textwrap.dedent(u'''
-            import pysnooper
-            @pysnooper.snoop(color=False)
-            def f(x):
-                return x
-        ''')
-        with python_file_path.open('w') as python_file:
-            python_file.write(content)
+        python_file_path = folder / zip_name / zip_base_path / ('%s.py' % (module_name))
+        os.makedirs(folder / zip_name / zip_base_path)
+        try:
+            sys.path.insert(0, str(folder / zip_name))
+            content = textwrap.dedent(u'''
+                import pysnooper
+                @pysnooper.snoop(color=False)
+                def f(x):
+                    return x
+            ''')
+            python_file_path.write_text(content)
 
-        module = importlib.import_module('%s.%s' % ('.'.join(zip_base_path.split('/')), module_name))
+            module = importlib.import_module('%s.%s' % ('.'.join(zip_base_path.split('/')), \
+                                                        module_name))
 
-        with zipfile.ZipFile(folder / 'foo_bar.zip', 'w') as myZipFile:
-            myZipFile.write(folder.joinpath('%s/%s/%s.py' % (zip_name, zip_base_path, module_name)), '%s/%s.py' % (zip_base_path, module_name,), zipfile.ZIP_DEFLATED)
+            with zipfile.ZipFile(folder / 'foo_bar.zip', 'w') as myZipFile:
+                myZipFile.write(folder / zip_name / zip_base_path / ('%s.py' % (module_name)), \
+                                '%s/%s.py' % (zip_base_path, module_name,), \
+                                zipfile.ZIP_DEFLATED)
 
-        python_file_path.unlink()
-        os.rename(folder.joinpath(zip_name), folder.joinpath('%s.delete' % (zip_name)),)
-        os.rename(folder / 'foo_bar.zip', folder.joinpath(zip_name),)
+            python_file_path.unlink()
+            folder.joinpath(zip_name).rename(folder.joinpath('%s.delete' % (zip_name)))
+            folder.joinpath('foo_bar.zip').rename(folder.joinpath(zip_name))
+            breakpoint()
+            with mini_toolbox.OutputCapturer(stdout=False,
+                                             stderr=True) as output_capturer:
+                result = getattr(module, 'f')(7)
+            assert result == 7
+            output = output_capturer.output
 
-        with mini_toolbox.OutputCapturer(stdout=False,
-                                         stderr=True) as output_capturer:
-            result = getattr(module, 'f')(7)
-        assert result == 7
-        output = output_capturer.output
-
-        assert_output(
-            output,
-            (
-                SourcePathEntry(),
-                VariableEntry(stage='starting'),
-                CallEntry('def f(x):'),
-                LineEntry('return x'),
-                ReturnEntry('return x'),
-                ReturnValueEntry('7'),
-                ElapsedTimeEntry(),
+            assert_output(
+                output,
+                (
+                    SourcePathEntry(),
+                    VariableEntry(stage='starting'),
+                    CallEntry('def f(x):'),
+                    LineEntry('return x'),
+                    ReturnEntry('return x'),
+                    ReturnValueEntry('7'),
+                    ElapsedTimeEntry(),
+                )
             )
-        )
+        finally:
+            sys.path.remove(str(folder / zip_name))
 
 
 def test_invalid_zipfile():
@@ -1971,45 +1976,50 @@ def test_invalid_zipfile():
         module_name = 'my_invalid_zip_module'
         zip_name = 'invalid.zip'
         zip_base_path = 'invalid/modules/path'
-        python_file_path = folder / ('%s/%s/%s.py' % (zip_name, zip_base_path, module_name))
-        os.makedirs(folder / ('%s/%s' % (zip_name, zip_base_path)))
-        sys.path.insert(0, str(folder / (zip_name)))
-        content = textwrap.dedent(u'''
-            import pysnooper
-            @pysnooper.snoop(color=False)
-            def f(x):
-                return x
-        ''')
-        with python_file_path.open('w') as python_file:
-            python_file.write(content)
+        python_file_path = folder / zip_name / zip_base_path / ('%s.py' % (module_name))
+        os.makedirs(folder / zip_name / zip_base_path)
+        try:
+            sys.path.insert(0, str(folder / zip_name))
+            content = textwrap.dedent(u'''
+                import pysnooper
+                @pysnooper.snoop(color=False)
+                def f(x):
+                    return x
+            ''')
+            python_file_path.write_text(content)
 
-        module = importlib.import_module('%s.%s' % ('.'.join(zip_base_path.split('/')), module_name))
+            module = importlib.import_module('%s.%s' % ('.'.join(zip_base_path.split('/')), \
+                                                        module_name))
 
-        with zipfile.ZipFile(folder / 'foo_bar.zip', 'w') as myZipFile:
-            myZipFile.write(folder.joinpath('%s/%s/%s.py' % (zip_name, zip_base_path, module_name)), '%s/%s.py' % (zip_base_path, module_name,), zipfile.ZIP_DEFLATED)
+            with zipfile.ZipFile(folder / 'foo_bar.zip', 'w') as myZipFile:
+                myZipFile.write(folder / zip_name / zip_base_path / ('%s.py' % (module_name)), \
+                                '%s/%s.py' % (zip_base_path, module_name,), \
+                                zipfile.ZIP_DEFLATED)
 
-        python_file_path.unlink()
-        os.rename(folder.joinpath(zip_name), folder.joinpath('%s.delete' % (zip_name)),)
-        os.rename(folder / 'foo_bar.zip', folder.joinpath(zip_name),)
-
-        with mini_toolbox.OutputCapturer(stdout=False,
+            python_file_path.unlink()
+            folder.joinpath(zip_name).rename(folder.joinpath('%s.delete' % (zip_name)))
+            folder.joinpath('foo_bar.zip').rename(folder.joinpath(zip_name))
+            breakpoint()
+            with mini_toolbox.OutputCapturer(stdout=False,
                                          stderr=True) as output_capturer:
-            result = getattr(module, 'f')(7)
-        assert result == 7
-        output = output_capturer.output
+                result = getattr(module, 'f')(7)
+            assert result == 7
+            output = output_capturer.output
 
-        assert_output(
-            output,
-            (
-                SourcePathEntry(),
-                VariableEntry(stage='starting'),
-                CallEntry('SOURCE IS UNAVAILABLE'),
-                LineEntry('SOURCE IS UNAVAILABLE'),
-                ReturnEntry('SOURCE IS UNAVAILABLE'),
-                ReturnValueEntry('7'),
-                ElapsedTimeEntry(),
+            assert_output(
+                output,
+                (
+                    SourcePathEntry(),
+                    VariableEntry(stage='starting'),
+                    CallEntry('SOURCE IS UNAVAILABLE'),
+                    LineEntry('SOURCE IS UNAVAILABLE'),
+                    ReturnEntry('SOURCE IS UNAVAILABLE'),
+                    ReturnValueEntry('7'),
+                    ElapsedTimeEntry(),
+                )
             )
-        )
+        finally:
+            sys.path.remove(str(folder / zip_name))
 
 
 def test_valid_damaged_zipfile():
@@ -2018,45 +2028,43 @@ def test_valid_damaged_zipfile():
         module_name = 'my_damaged_module'
         zip_name = 'damaged.zip'
         zip_base_path = 'ansible/modules'
-        python_file_path = folder / ('%s/%s/%s.py' % (zip_name, zip_base_path, module_name))
-        os.makedirs(folder / ('%s/%s' % (zip_name, zip_base_path)))
-        sys.path.insert(0, str(folder / (zip_name)))
-        content = textwrap.dedent(u'''
-            import pysnooper
-            @pysnooper.snoop(color=False)
-            def f(x):
-                return x
-        ''')
-        with python_file_path.open('w') as python_file:
-            python_file.write(content)
+        python_file_path = folder / zip_name / zip_base_path / ('%s.py' % (module_name))
+        os.makedirs(folder / zip_name / zip_base_path)
+        try:
+            sys.path.insert(0, str(folder / zip_name))
+            content = textwrap.dedent(u'''
+                import pysnooper
+                @pysnooper.snoop(color=False)
+                def f(x):
+                    return x
+            ''')
+            python_file_path.write_text(content)
 
-        module = importlib.import_module('%s.%s' % ('.'.join(zip_base_path.split('/')), module_name))
+            module = importlib.import_module('%s.%s' % ('.'.join(zip_base_path.split('/')), \
+                                                        module_name))
 
-        python_file_path.unlink()
-        os.rename(folder.joinpath(zip_name), folder.joinpath('%s.delete' % (zip_name)),)
+            python_file_path.unlink()
+            folder.joinpath(zip_name).rename(folder.joinpath('%s.delete' % (zip_name)))
 
-        content_damaged_zip = textwrap.dedent(u'''
-            I am not a zip file
-        ''')
-
-        with folder.joinpath(zip_name).open('w') as damaged_zip_file:
-            damaged_zip_file.write(content_damaged_zip)
-
-        with mini_toolbox.OutputCapturer(stdout=False,
+            folder.joinpath(zip_name).write_text('I am not a zip file')
+            breakpoint()
+            with mini_toolbox.OutputCapturer(stdout=False,
                                          stderr=True) as output_capturer:
-            result = getattr(module, 'f')(7)
-        assert result == 7
-        output = output_capturer.output
+                result = getattr(module, 'f')(7)
+            assert result == 7
+            output = output_capturer.output
 
-        assert_output(
-            output,
-            (
-                SourcePathEntry(),
-                VariableEntry(stage='starting'),
-                CallEntry('SOURCE IS UNAVAILABLE'),
-                LineEntry('SOURCE IS UNAVAILABLE'),
-                ReturnEntry('SOURCE IS UNAVAILABLE'),
-                ReturnValueEntry('7'),
-                ElapsedTimeEntry(),
+            assert_output(
+                output,
+                (
+                    SourcePathEntry(),
+                    VariableEntry(stage='starting'),
+                    CallEntry('SOURCE IS UNAVAILABLE'),
+                    LineEntry('SOURCE IS UNAVAILABLE'),
+                    ReturnEntry('SOURCE IS UNAVAILABLE'),
+                    ReturnValueEntry('7'),
+                    ElapsedTimeEntry(),
+                )
             )
-        )
+        finally:
+            sys.path.remove(str(folder / zip_name))

--- a/tests/test_utils/test_regex.py
+++ b/tests/test_utils/test_regex.py
@@ -35,6 +35,12 @@ def test_ansible_filename_pattern():
     assert ansible_filename_pattern.match(file_name).group(1) == archive_file
     assert ansible_filename_pattern.match(file_name).group(2) == source_code_file
 
+    archive_file = 'C:\\Users\\vagrant\\AppData\\Local\\Temp\\pysnooperw5c2lg35\\valid.zip'
+    source_code_file = 'ansible\\modules\\my_valid_zip_module.py'
+    file_name = '%s\\%s' % (archive_file, source_code_file)
+    assert ansible_filename_pattern.match(file_name).group(1) == archive_file
+    assert ansible_filename_pattern.match(file_name).group(2) == source_code_file
+
     archive_file = '/tmp/ansible_my_module_payload_xyz1234/ansible_my_module_payload.zip'
     source_code_file = 'ANSIBLE/modules/my_module.py'
     file_name = '%s/%s' % (archive_file, source_code_file)
@@ -64,9 +70,3 @@ def test_ansible_filename_pattern():
     source_code_file = 'ansible/modules/my_module.py'
     file_name = '%s/%s' % (archive_file, source_code_file)
     assert ansible_filename_pattern.match(file_name) is None
-
-
-
-
-
-

--- a/tests/test_utils/test_regex.py
+++ b/tests/test_utils/test_regex.py
@@ -1,0 +1,72 @@
+# Copyright 2022 Ram Rachum and collaborators.
+# This program is distributed under the MIT license.
+
+import pysnooper
+from pysnooper.tracer import ansible_filename_pattern
+
+def test_ansible_filename_pattern():
+    archive_file = '/tmp/ansible_my_module_payload_xyz1234/ansible_my_module_payload.zip'
+    source_code_file = 'ansible/modules/my_module.py'
+    file_name = archive_file + '/' + source_code_file
+    assert ansible_filename_pattern.match(file_name).group(1) == archive_file
+    assert ansible_filename_pattern.match(file_name).group(2) == source_code_file
+
+    archive_file = '/tmp/ansible_my_module_payload_xyz1234/ansible_my_module_with.zip_name.zip'
+    source_code_file = 'ansible/modules/my_module.py'
+    file_name = archive_file + '/' + source_code_file
+    assert ansible_filename_pattern.match(file_name).group(1) == archive_file
+    assert ansible_filename_pattern.match(file_name).group(2) == source_code_file
+    
+    archive_file = '/my/new/path/payload.zip'
+    source_code_file = 'ansible/modules/my_module.py'
+    file_name = archive_file + '/' + source_code_file
+    assert ansible_filename_pattern.match(file_name).group(1) == archive_file
+    assert ansible_filename_pattern.match(file_name).group(2) == source_code_file
+
+    archive_file = '/tmp/ansible_my_module_payload_xyz1234/ansible_my_module_payload.zip'
+    source_code_file = 'ansible/modules/in/new/path/my_module.py'
+    file_name = archive_file + '/' + source_code_file
+    assert ansible_filename_pattern.match(file_name).group(1) == archive_file
+    assert ansible_filename_pattern.match(file_name).group(2) == source_code_file
+    
+    archive_file = '/tmp/ansible_my_module_payload_xyz1234/ansible_my_module_payload.zip'
+    source_code_file = 'ansible/modules/my_module_is_called_.py.py'
+    file_name = archive_file + '/' + source_code_file
+    assert ansible_filename_pattern.match(file_name).group(1) == archive_file
+    assert ansible_filename_pattern.match(file_name).group(2) == source_code_file
+
+    archive_file = '/tmp/ansible_my_module_payload_xyz1234/ansible_my_module_payload.zip'
+    source_code_file = 'ANSIBLE/modules/my_module.py'
+    file_name = archive_file + '/' + source_code_file
+    assert ansible_filename_pattern.match(file_name) == None
+
+    archive_file = '/tmp/ansible_my_module_payload_xyz1234/ansible_my_module_payload.zip'
+    source_code_file = 'ansible/modules/my_module.PY'
+    file_name = archive_file + '/' + source_code_file
+    assert ansible_filename_pattern.match(file_name) == None
+
+    archive_file = '/tmp/ansible_my_module_payload_xyz1234/ansible_my_module_payload.Zip'
+    source_code_file = 'ansible/modules/my_module.py'
+    file_name = archive_file + '/' + source_code_file
+    assert ansible_filename_pattern.match(file_name) == None
+
+    archive_file = '/tmp/ansible_my_module_payload_xyz1234/ansible_my_module_payload.zip'
+    source_code_file = 'ansible/my_module.py'
+    file_name = archive_file + '/' + source_code_file
+    assert ansible_filename_pattern.match(file_name) == None
+
+    archive_file = '/tmp/ansible_my_module_payload_xyz1234/ansible_my_module_payload.zip'
+    source_code_file = ''
+    file_name = archive_file + '/' + source_code_file
+    assert ansible_filename_pattern.match(file_name) == None
+
+    archive_file = ''
+    source_code_file = 'ansible/modules/my_module.py'
+    file_name = archive_file + '/' + source_code_file
+    assert ansible_filename_pattern.match(file_name) == None
+
+
+
+
+
+

--- a/tests/test_utils/test_regex.py
+++ b/tests/test_utils/test_regex.py
@@ -7,63 +7,63 @@ from pysnooper.tracer import ansible_filename_pattern
 def test_ansible_filename_pattern():
     archive_file = '/tmp/ansible_my_module_payload_xyz1234/ansible_my_module_payload.zip'
     source_code_file = 'ansible/modules/my_module.py'
-    file_name = archive_file + '/' + source_code_file
+    file_name = '%s/%s' % (archive_file, source_code_file)
     assert ansible_filename_pattern.match(file_name).group(1) == archive_file
     assert ansible_filename_pattern.match(file_name).group(2) == source_code_file
 
     archive_file = '/tmp/ansible_my_module_payload_xyz1234/ansible_my_module_with.zip_name.zip'
     source_code_file = 'ansible/modules/my_module.py'
-    file_name = archive_file + '/' + source_code_file
+    file_name = '%s/%s' % (archive_file, source_code_file)
     assert ansible_filename_pattern.match(file_name).group(1) == archive_file
     assert ansible_filename_pattern.match(file_name).group(2) == source_code_file
     
     archive_file = '/my/new/path/payload.zip'
     source_code_file = 'ansible/modules/my_module.py'
-    file_name = archive_file + '/' + source_code_file
+    file_name = '%s/%s' % (archive_file, source_code_file)
     assert ansible_filename_pattern.match(file_name).group(1) == archive_file
     assert ansible_filename_pattern.match(file_name).group(2) == source_code_file
 
     archive_file = '/tmp/ansible_my_module_payload_xyz1234/ansible_my_module_payload.zip'
     source_code_file = 'ansible/modules/in/new/path/my_module.py'
-    file_name = archive_file + '/' + source_code_file
+    file_name = '%s/%s' % (archive_file, source_code_file)
     assert ansible_filename_pattern.match(file_name).group(1) == archive_file
     assert ansible_filename_pattern.match(file_name).group(2) == source_code_file
     
     archive_file = '/tmp/ansible_my_module_payload_xyz1234/ansible_my_module_payload.zip'
     source_code_file = 'ansible/modules/my_module_is_called_.py.py'
-    file_name = archive_file + '/' + source_code_file
+    file_name = '%s/%s' % (archive_file, source_code_file)
     assert ansible_filename_pattern.match(file_name).group(1) == archive_file
     assert ansible_filename_pattern.match(file_name).group(2) == source_code_file
 
     archive_file = '/tmp/ansible_my_module_payload_xyz1234/ansible_my_module_payload.zip'
     source_code_file = 'ANSIBLE/modules/my_module.py'
-    file_name = archive_file + '/' + source_code_file
-    assert ansible_filename_pattern.match(file_name) == None
+    file_name = '%s/%s' % (archive_file, source_code_file)
+    assert ansible_filename_pattern.match(file_name) is None
 
     archive_file = '/tmp/ansible_my_module_payload_xyz1234/ansible_my_module_payload.zip'
     source_code_file = 'ansible/modules/my_module.PY'
-    file_name = archive_file + '/' + source_code_file
-    assert ansible_filename_pattern.match(file_name) == None
+    file_name = '%s/%s' % (archive_file, source_code_file)
+    assert ansible_filename_pattern.match(file_name) is None
 
     archive_file = '/tmp/ansible_my_module_payload_xyz1234/ansible_my_module_payload.Zip'
     source_code_file = 'ansible/modules/my_module.py'
-    file_name = archive_file + '/' + source_code_file
-    assert ansible_filename_pattern.match(file_name) == None
+    file_name = '%s/%s' % (archive_file, source_code_file)
+    assert ansible_filename_pattern.match(file_name) is None
 
     archive_file = '/tmp/ansible_my_module_payload_xyz1234/ansible_my_module_payload.zip'
     source_code_file = 'ansible/my_module.py'
-    file_name = archive_file + '/' + source_code_file
-    assert ansible_filename_pattern.match(file_name) == None
+    file_name = '%s/%s' % (archive_file, source_code_file)
+    assert ansible_filename_pattern.match(file_name) is None
 
     archive_file = '/tmp/ansible_my_module_payload_xyz1234/ansible_my_module_payload.zip'
     source_code_file = ''
-    file_name = archive_file + '/' + source_code_file
-    assert ansible_filename_pattern.match(file_name) == None
+    file_name = '%s/%s' % (archive_file, source_code_file)
+    assert ansible_filename_pattern.match(file_name) is None
 
     archive_file = ''
     source_code_file = 'ansible/modules/my_module.py'
-    file_name = archive_file + '/' + source_code_file
-    assert ansible_filename_pattern.match(file_name) == None
+    file_name = '%s/%s' % (archive_file, source_code_file)
+    assert ansible_filename_pattern.match(file_name) is None
 
 
 


### PR DESCRIPTION
# Ansible zipped source support

## Scope
It would be great to support Ansible zipped source files to make Ansible module debugging available in PySnooper

## Problem
Ansible is using zipped source files on the remote node. 
To get access to the source file itself you need to unzip the file during runtime.
The source file will be deleted after execution.

```
Source path:... /tmp/ansible_my_module_payload_xyz1234/ansible_my_module_payload.zip/ansible/modules/my_module.py
Modified var:.. result = {'changed': True, 'original_message': 'hello', 'message': 'goodbye'}
09:25:25.942249 line       127 SOURCE IS UNAVAILABLE
09:25:25.942279 line       132 SOURCE IS UNAVAILABLE
09:25:25.942303 line       133 SOURCE IS UNAVAILABLE
```

## Solution
I added a condition to tracer.py like the condition for ipython to unzip the source file and get read access. 

```
Source path:... /tmp/ansible_my_module_payload_xyz1234/ansible_my_module_payload.zip/ansible/modules/my_module.py
Modified var:.. result = {'changed': True, 'original_message': 'hello', 'message': 'goodbye'}
09:26:58.498181 line       127     if module.params['name'] == 'fail me':
09:26:58.498211 line       132     if module.params['debug']:
09:26:58.498235 line       133         result['debug'] = pydebug.getvalue()
```
