### PR TITLE
Use Thread.name instead of deprecated getName

### DIFF
--- a/misc/IDE files/PySnooper.wpr
+++ b/misc/IDE files/PySnooper.wpr
@@ -5,9 +5,12 @@
 ##################################################################
 [project attributes]
 proj.directory-list = [{'dirloc': loc('../..'),
-                        'excludes': ['PySnooper.egg-info',
-                                     'dist',
-                                     'build'],
+                        'excludes': ['dist',
+                                     '.tox',
+                                     'htmlcov',
+                                     'build',
+                                     '.ipynb_checkpoints',
+                                     'PySnooper.egg-info'],
                         'filter': '*',
                         'include_hidden': False,
                         'recursive': True,

--- a/pysnooper/tracer.py
+++ b/pysnooper/tracer.py
@@ -472,7 +472,7 @@ class Tracer:
                                           "thread_info")
             current_thread = threading.current_thread()
             thread_info = "{ident}-{name} ".format(
-                ident=current_thread.ident, name=current_thread.getName())
+                ident=current_thread.ident, name=current_thread.name)
         thread_info = self.set_thread_info_padding(thread_info)
 
         ### Reporting newish and modified variables: ##########################


### PR DESCRIPTION
- Python 3.12 compat: Include new return opcodes
- Use Thread.name instead of deprecated getName
