### PR TITLE
Allow forcing color output on Windows using `color=True` #229

### DIFF
--- a/pysnooper/tracer.py
+++ b/pysnooper/tracer.py
@@ -225,7 +225,9 @@ class Tracer:
 
         @pysnooper.snoop(relative_time=True)
 
-    The output is colored for easy viewing by default, except on Windows.
+    The output is colored for easy viewing by default, except on Windows
+    (but can be enabled by setting `color=True`).
+
     Disable colors like so:
 
         @pysnooper.snoop(color=False)
@@ -234,7 +236,7 @@ class Tracer:
     def __init__(self, output=None, watch=(), watch_explode=(), depth=1,
                  prefix='', overwrite=False, thread_info=False, custom_repr=(),
                  max_variable_length=100, normalize=False, relative_time=False,
-                 color=True):
+                 color=sys.platform in ('linux', 'linux2', 'cygwin', 'darwin')):
         self._write = get_write_function(output, overwrite)
 
         self.watch = [
@@ -262,8 +264,7 @@ class Tracer:
         self.max_variable_length = max_variable_length
         self.normalize = normalize
         self.relative_time = relative_time
-        self.color = color and sys.platform in ('linux', 'linux2', 'cygwin',
-                                                'darwin')
+        self.color = color
 
         if self.color:
             self._FOREGROUND_BLUE = '\x1b[34m'


### PR DESCRIPTION
As described in https://github.com/cool-RR/PySnooper/issues/229#issuecomment-2781296738, color output now is completely disabled on Windows. 

But since it's now used on Windows more widely, this PR removes this restriction and setting default value for `color` argument in `snoop` based on the current platform. Default value set to `True` on all other platforms besides Windows. This allows Windows users to access color output by using `snoop(color=True)`.

I guess, the only caveat of this PR is that default value now is platform-dependant and in theory someone can have a script with `snoop(color=True)` on Unix and when it's going to be executed on Windows, it will result in scary ANSI color codes. But it's all purely hypothetical since pysnooper is just a personal debugging tool.